### PR TITLE
Add a stub cluster_api driver

### DIFF
--- a/magnum_capi_helm/driver.py
+++ b/magnum_capi_helm/driver.py
@@ -1,0 +1,85 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from oslo_log import log as logging
+
+from magnum.drivers.common import driver
+
+LOG = logging.getLogger(__name__)
+
+
+class Driver(driver.Driver):
+    @property
+    def provides(self):
+        return [
+            {
+                "server_type": "vm",
+                # TODO(johngarbutt) OS list should probably come from config?
+                "os": "ubuntu",
+                "coe": "kubernetes",
+            },
+        ]
+
+    def update_cluster_status(self, context, cluster):
+        raise NotImplementedError("don't support update_cluster_status yet")
+
+    def create_cluster(self, context, cluster, cluster_create_timeout):
+        raise NotImplementedError("don't support create yet")
+
+    def update_cluster(
+        self, context, cluster, scale_manager=None, rollback=False
+    ):
+        raise NotImplementedError("don't support update yet")
+
+    def delete_cluster(self, context, cluster):
+        raise NotImplementedError("don't support delete yet")
+
+    def resize_cluster(
+        self,
+        context,
+        cluster,
+        resize_manager,
+        node_count,
+        nodes_to_remove,
+        nodegroup=None,
+    ):
+        raise NotImplementedError("don't support removing nodes this way yet")
+
+    def upgrade_cluster(
+        self,
+        context,
+        cluster,
+        cluster_template,
+        max_batch_size,
+        nodegroup,
+        scale_manager=None,
+        rollback=False,
+    ):
+        raise NotImplementedError("don't support upgrade yet")
+
+    def create_nodegroup(self, context, cluster, nodegroup):
+        raise NotImplementedError("we don't support node groups yet")
+
+    def update_nodegroup(self, context, cluster, nodegroup):
+        raise NotImplementedError("we don't support node groups yet")
+
+    def delete_nodegroup(self, context, cluster, nodegroup):
+        raise NotImplementedError("we don't support node groups yet")
+
+    def create_federation(self, context, federation):
+        raise NotImplementedError("Will not implement 'create_federation'")
+
+    def update_federation(self, context, federation):
+        raise NotImplementedError("Will not implement 'update_federation'")
+
+    def delete_federation(self, context, federation):
+        raise NotImplementedError("Will not implement 'delete_federation'")

--- a/magnum_capi_helm/tests/test_driver.py
+++ b/magnum_capi_helm/tests/test_driver.py
@@ -1,0 +1,141 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from magnum import objects
+from magnum.tests.unit.db import base
+from magnum.tests.unit.objects import utils as obj_utils
+
+from magnum_capi_helm import driver
+
+
+class ClusterAPIDriverTest(base.DbTestCase):
+    def setUp(self):
+        super(ClusterAPIDriverTest, self).setUp()
+        self.driver = driver.Driver()
+        self.cluster_obj = obj_utils.create_test_cluster(
+            self.context,
+            name="cluster_example_$A",
+            master_flavor_id="flavor_small",
+            flavor_id="flavor_medium",
+        )
+
+    def test_provides(self):
+        self.assertEqual(
+            [{"server_type": "vm", "os": "ubuntu", "coe": "kubernetes"}],
+            self.driver.provides,
+        )
+
+    def test_update_cluster_status(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.driver.update_cluster_status,
+            self.context,
+            self.cluster_obj,
+        )
+
+    def test_create_cluster(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.driver.create_cluster,
+            self.context,
+            self.cluster_obj,
+            cluster_create_timeout=10,
+        )
+
+    def test_delete_cluster(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.driver.delete_cluster,
+            self.context,
+            self.cluster_obj,
+        )
+
+    def test_update_cluster(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.driver.update_cluster,
+            self.context,
+            self.cluster_obj,
+        )
+
+    def test_resize_cluster(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.driver.resize_cluster,
+            self.context,
+            self.cluster_obj,
+            None,
+            4,
+            None,
+        )
+
+    def test_upgrade_cluster(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.driver.upgrade_cluster,
+            self.context,
+            self.cluster_obj,
+            self.cluster_obj.cluster_template,
+            1,
+            None,
+        )
+
+    def test_create_nodegroup(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.driver.create_nodegroup,
+            self.context,
+            self.cluster_obj,
+            objects.NodeGroup(),
+        )
+
+    def test_update_nodegroup(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.driver.update_nodegroup,
+            self.context,
+            self.cluster_obj,
+            objects.NodeGroup(),
+        )
+
+    def test_delete_nodegroup(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.driver.delete_nodegroup,
+            self.context,
+            self.cluster_obj,
+            objects.NodeGroup(),
+        )
+
+    def test_create_federation(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.driver.create_federation,
+            self.context,
+            None,
+        )
+
+    def test_update_federation(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.driver.update_federation,
+            self.context,
+            None,
+        )
+
+    def test_delete_federation(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.driver.delete_federation,
+            self.context,
+            None,
+        )

--- a/magnum_capi_helm/tests/test_magnum_capi_helm.py
+++ b/magnum_capi_helm/tests/test_magnum_capi_helm.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at
@@ -12,16 +10,13 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-"""
-test_magnum_capi_helm
-----------------------------------
+from magnum.drivers.common import driver as common
 
-Tests for `magnum_capi_helm` module.
-"""
-
+from magnum_capi_helm import driver
 from magnum_capi_helm.tests import base
 
 
-class TestMagnum_capi_helm(base.TestCase):
-    def test_something(self):
-        pass
+class TestMagnumDriverLoads(base.TestCase):
+    def test_get_driver(self):
+        cluster_driver = common.Driver.get_driver("vm", "ubuntu", "kubernetes")
+        self.assertIsInstance(cluster_driver, driver.Driver)

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,3 +24,7 @@ classifier =
 [files]
 packages =
     magnum_capi_helm
+
+[entry_points]
+magnum.drivers =
+    k8s_capi_helm_v1 = magnum_capi_helm.driver:Driver

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,6 @@
 [tox]
-minversion = 3.2.0
+minversion = 3.18.0
 envlist = py3,black,pep8
-skipsdist = True
-ignore_basepython_conflict = true
-
 
 [testenv]
 basepython = python3
@@ -14,6 +11,7 @@ setenv =
    OS_STDERR_CAPTURE=1
    OS_TEST_TIMEOUT=60
 deps = -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+       -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands = stestr run {posargs}
 


### PR DESCRIPTION
The plan is to slowly build up the ability to create K8s CRDs instead of heat templates in a separate driver.
The starting point is adding the new experimental driver.

Extracted from:
https://review.opendev.org/c/openstack/magnum/+/815521

Change-Id: I32b7a91640f4f65b9662de080682761a2c182055