### PR TITLE
Add Helm client

### DIFF
--- a/magnum_capi_helm/conf.py
+++ b/magnum_capi_helm/conf.py
@@ -1,0 +1,34 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from oslo_config import cfg
+
+capi_helm_group = cfg.OptGroup(
+    name="capi_helm", title="Helm Cluster API Driver configuration"
+)
+
+capi_helm_opts = [
+    cfg.StrOpt(
+        "kubeconfig_file",
+        default="",
+        help=(
+            "Path to a kubeconfig file for a management cluster,"
+            "for use in the Cluster API driver. "
+            "Defaults to the environment variable KUBECONFIG, "
+            "or if not defined ~/.kube/config"
+        ),
+    )
+]
+
+CONF = cfg.CONF
+CONF.register_group(capi_helm_group)
+CONF.register_opts(capi_helm_opts, group=capi_helm_group)

--- a/magnum_capi_helm/helm.py
+++ b/magnum_capi_helm/helm.py
@@ -1,0 +1,129 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import functools
+import json
+import pathlib
+import typing as t
+
+from magnum.common import utils
+from oslo_concurrency import processutils
+from oslo_log import log as logging
+
+from magnum_capi_helm import conf
+
+LOG = logging.getLogger(__name__)
+CONF = conf.CONF
+
+
+def mergeconcat(defaults, *overrides):
+    """Deep-merge two or more dictionaries together.
+
+    Lists are concatenated.
+    """
+
+    def mergeconcat2(defaults, overrides):
+        if isinstance(defaults, dict) and isinstance(overrides, dict):
+            merged = dict(defaults)
+            for key, value in overrides.items():
+                if key in defaults:
+                    merged[key] = mergeconcat2(defaults[key], value)
+                else:
+                    merged[key] = value
+            return merged
+        elif isinstance(defaults, (list, tuple)) and isinstance(
+            overrides, (list, tuple)
+        ):
+            merged = list(defaults)
+            merged.extend(overrides)
+            return merged
+        else:
+            return overrides if overrides is not None else defaults
+
+    return functools.reduce(mergeconcat2, overrides, defaults)
+
+
+class Client:
+    """Client for interacting with Helm CLI."""
+
+    def __init__(self):
+        self._default_timeout = "5m"
+        self._executable = "helm"
+        self._history_max_revisions = 10
+        self._kubeconfig = CONF.capi_helm.kubeconfig_file
+
+    def _run(self, command, **kwargs) -> bytes:
+        command = [self._executable] + command
+        if self._kubeconfig:
+            command.extend(["--kubeconfig", self._kubeconfig])
+        stdout, stderr = utils.execute(*command, **kwargs)
+        LOG.debug(f"Ran helm {command} got out:{stdout} err:{stderr}")
+        return stdout
+
+    def install_or_upgrade(
+        self,
+        release_name: str,
+        chart_ref: t.Union[pathlib.Path, str],
+        *values: t.Dict[str, t.Any],
+        namespace: str,
+        repo: t.Optional[str] = None,
+        version: t.Optional[str] = None,
+    ) -> t.Iterable[t.Dict[str, t.Any]]:
+        """Install or upgrade specified release using chart and values."""
+        command = [
+            "upgrade",
+            release_name,
+            chart_ref,
+            "--history-max",
+            self._history_max_revisions,
+            "--install",
+            "--output",
+            "json",
+            "--timeout",
+            self._default_timeout,
+            # We send the values in on stdin
+            "--values",
+            "-",
+            "--namespace",
+            namespace,
+        ]
+        if repo:
+            command += ["--repo", repo]
+        if version:
+            command += [
+                "--version",
+                version,
+            ]
+
+        process_input = json.dumps(mergeconcat({}, *values))
+        return json.loads(self._run(command, process_input=process_input))
+
+    def uninstall_release(
+        self,
+        release_name: str,
+        namespace: str,
+    ):
+        """Uninstall the named release."""
+        command = [
+            "uninstall",
+            release_name,
+            "--timeout",
+            self._default_timeout,
+            "--namespace",
+            namespace,
+        ]
+        try:
+            self._run(command)
+        except processutils.ProcessExecutionError as exc:
+            # Swallow release not found errors, as that is our desired state
+            if not exc.stderr or "release: not found" not in exc.stderr:
+                raise

--- a/magnum_capi_helm/tests/test_helm.py
+++ b/magnum_capi_helm/tests/test_helm.py
@@ -1,0 +1,163 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from unittest import mock
+
+from magnum.common import utils
+from oslo_concurrency import processutils
+
+from magnum_capi_helm import helm
+from magnum_capi_helm.tests import base
+
+
+class TestHelmClient(base.TestCase):
+    def test_mergeconcat_dicts(self):
+        defaults = dict(foo="bar", asdf=dict(a="b", c="d"))
+        overrides = dict(asdf=dict(a="c"))
+
+        result = helm.mergeconcat(defaults, overrides)
+
+        expected = dict(foo="bar", asdf=dict(a="c", c="d"))
+        self.assertEqual(expected, result)
+
+    def test_mergeconcat_list(self):
+        defaults = ["foo", "bar"]
+        overrides = ["bar", "baz"]
+
+        result = helm.mergeconcat(defaults, overrides)
+
+        expected = ["foo", "bar", "bar", "baz"]
+        self.assertEqual(expected, result)
+
+    @mock.patch.object(utils, "execute")
+    def test_install_or_upgrade(self, mock_execute):
+        mock_execute.return_value = '[{"foo": "bar"}]', ""
+
+        client = helm.Client()
+        result = client.install_or_upgrade(
+            "myfirstcluster",
+            "mychart",
+            dict(foo="bar", b=42),
+            repo="http://myrepo",
+            version="v1.42",
+            namespace="mynamespace",
+        )
+
+        self.assertEqual([{"foo": "bar"}], result)
+        mock_execute.assert_called_once_with(
+            "helm",
+            "upgrade",
+            "myfirstcluster",
+            "mychart",
+            "--history-max",
+            10,
+            "--install",
+            "--output",
+            "json",
+            "--timeout",
+            "5m",
+            "--values",
+            "-",
+            "--namespace",
+            "mynamespace",
+            "--repo",
+            "http://myrepo",
+            "--version",
+            "v1.42",
+            process_input='{"foo": "bar", "b": 42}',
+        )
+
+    @mock.patch.object(utils, "execute")
+    def test_install_or_upgrade_oci(self, mock_execute):
+        mock_execute.return_value = '[{"foo": "bar"}]', ""
+
+        client = helm.Client()
+        result = client.install_or_upgrade(
+            "myfirstcluster",
+            "oci://localhost:5000/helm-charts/mychart",
+            dict(foo="bar", b=42),
+            version="v1.42",
+            namespace="mynamespace",
+        )
+
+        self.assertEqual([{"foo": "bar"}], result)
+        mock_execute.assert_called_once_with(
+            "helm",
+            "upgrade",
+            "myfirstcluster",
+            "oci://localhost:5000/helm-charts/mychart",
+            "--history-max",
+            10,
+            "--install",
+            "--output",
+            "json",
+            "--timeout",
+            "5m",
+            "--values",
+            "-",
+            "--namespace",
+            "mynamespace",
+            "--version",
+            "v1.42",
+            process_input='{"foo": "bar", "b": 42}',
+        )
+
+    @mock.patch.object(helm.CONF, "capi_helm")
+    @mock.patch.object(utils, "execute")
+    def test_uninstall_release_works(self, mock_execute, mock_conf):
+        mock_execute.return_value = "", ""
+        mock_conf.kubeconfig_file = "/etc/magnum/kubeconfig"
+
+        client = helm.Client()
+        result = client.uninstall_release(
+            "myfirstcluster", namespace="mynamespace"
+        )
+
+        self.assertIsNone(result)
+        mock_execute.assert_called_once_with(
+            "helm",
+            "uninstall",
+            "myfirstcluster",
+            "--timeout",
+            "5m",
+            "--namespace",
+            "mynamespace",
+            "--kubeconfig",
+            "/etc/magnum/kubeconfig",
+        )
+
+    @mock.patch.object(utils, "execute")
+    def test_uninstall_release_ignore_not_found(self, mock_execute):
+        mock_execute.side_effect = processutils.ProcessExecutionError(
+            stderr="release: not found"
+        )
+
+        client = helm.Client()
+        result = client.uninstall_release(
+            "myfirstcluster", namespace="mynamespace"
+        )
+
+        self.assertIsNone(result)
+
+    @mock.patch.object(utils, "execute")
+    def test_uninstall_release_raises(self, mock_execute):
+        mock_execute.side_effect = processutils.ProcessExecutionError(
+            stderr="oh dear!"
+        )
+        client = helm.Client()
+
+        self.assertRaises(
+            processutils.ProcessExecutionError,
+            client.uninstall_release,
+            "myfirstcluster",
+            namespace="mynamespace",
+        )


### PR DESCRIPTION
The Cluster API driver will be creating and delting K8s clusters by using a helm chart. To do this we need a simple way to manipulate helm charts.

We know oslo process utils are evetlet frindly, hence the choice to depend on the helm CLI.

We add an extra configuration value to optionally specify where the kubeconfig lives: [drivers]kubeconfig_file

By default, no kubeconfig is specified, and so the default locations of the helm CLI are searched.

Based on:
https://review.opendev.org/c/openstack/magnum/+/881393

Change-Id: Ie52e73d779eacb52dae495ded0dcdd39ad93687f