### PR TITLE
Cluster API: use helm client in driver

### DIFF
--- a/magnum_capi_helm/conf.py
+++ b/magnum_capi_helm/conf.py
@@ -26,7 +26,46 @@ capi_helm_opts = [
             "Defaults to the environment variable KUBECONFIG, "
             "or if not defined ~/.kube/config"
         ),
-    )
+    ),
+    cfg.StrOpt(
+        "namespace_suffix",
+        default="magnum",
+        help=(
+            "Resources for each openstack cluster are created in a "
+            "separate namespace within the CAPI Management cluster "
+            "specified by the configuration: [capi_helm]kubeconfig_file "
+            "You should modify this suffix when two magnum deployments "
+            "want to share a single CAPI management cluster."
+        ),
+    ),
+    cfg.StrOpt(
+        "helm_chart_repo",
+        default="https://stackhpc.github.io/capi-helm-charts",
+        help=(
+            "Reference to the helm chart repository for "
+            "the cluster API driver. "
+            "Note that if helm_chart_name starts with oci:// "
+            "you will want this to set this to the empty string."
+        ),
+    ),
+    cfg.StrOpt(
+        "helm_chart_name",
+        default="openstack-cluster",
+        help=(
+            "Name of the helm chart to use from the repo specified "
+            "by the config: capi_driver.helm_chart_repo"
+        ),
+    ),
+    cfg.StrOpt(
+        "default_helm_chart_version",
+        default="0.1.1-dev.0.main.221",
+        help=(
+            "Version of the helm chart specified "
+            "by the config: capi_driver.helm_chart_repo "
+            "and capi_driver.helm_chart_name. "
+            "A cluster label can override this."
+        ),
+    ),
 ]
 
 CONF = cfg.CONF

--- a/magnum_capi_helm/driver.py
+++ b/magnum_capi_helm/driver.py
@@ -9,21 +9,31 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+import re
 
+from magnum.api import utils as api_utils
+from magnum.common import clients
+from magnum.common import exception
+from magnum.common import short_id
+from magnum.drivers.common import driver
 from oslo_log import log as logging
 
-from magnum.drivers.common import driver
+from magnum_capi_helm import conf
+from magnum_capi_helm import helm
 
 LOG = logging.getLogger(__name__)
+CONF = conf.CONF
 
 
 class Driver(driver.Driver):
+    def __init__(self):
+        self._helm_client = helm.Client()
+
     @property
     def provides(self):
         return [
             {
                 "server_type": "vm",
-                # TODO(johngarbutt) OS list should probably come from config?
                 "os": "ubuntu",
                 "coe": "kubernetes",
             },
@@ -32,8 +42,170 @@ class Driver(driver.Driver):
     def update_cluster_status(self, context, cluster):
         raise NotImplementedError("don't support update_cluster_status yet")
 
+    def _namespace(self, cluster):
+        # We create clusters in a project-specific namespace
+        # To generate the namespace, first sanitize the project id
+        project_id = re.sub("[^a-z0-9]", "", cluster.project_id.lower())
+        suffix = CONF.capi_helm.namespace_suffix
+        return f"{suffix}-{project_id}"
+
+    def _label(self, cluster, key, default):
+        all_labels = helm.mergeconcat(
+            cluster.cluster_template.labels, cluster.labels
+        )
+        if not all_labels:
+            return default
+        raw = all_labels.get(key, default)
+        # NOTE(johngarbutt): filtering untrusted user input
+        return re.sub(r"[^a-zA-Z0-9\.\-\/ ]+", "", raw)
+
+    def _get_chart_version(self, cluster):
+        version = cluster.cluster_template.labels.get(
+            "capi_helm_chart_version",
+            CONF.capi_helm.default_helm_chart_version,
+        )
+        # NOTE(johngarbutt): filtering untrusted user input
+        return re.sub(r"[^a-z0-9\.\-]+", "", version)
+
+    def _sanitized_name(self, name, suffix=None):
+        return re.sub(
+            "[^a-z0-9]+",
+            "-",
+            (f"{name}-{suffix}" if suffix else name).lower(),
+        )
+
+    def _get_kube_version(self, image):
+        # The image should have a property containing the Kubernetes version
+        kube_version = image.get("kube_version")
+        if not kube_version:
+            raise exception.MagnumException(
+                message=f"Image {image.id} does not "
+                "have a kube_version property."
+            )
+        raw = kube_version.lstrip("v")
+        # TODO(johngarbutt) more validation required?
+        return re.sub(r"[^0-9\.]+", "", raw)
+
+    def _get_image_details(self, context, image_identifier):
+        osc = clients.OpenStackClients(context)
+        image = api_utils.get_openstack_resource(
+            osc.glance().images, image_identifier, "images"
+        )
+        return image.id, self._get_kube_version(image)
+
+    def _get_app_cred_name(self, cluster):
+        return self._sanitized_name(
+            self._get_chart_release_name(cluster), "cloud-credentials"
+        )
+
+    def _get_monitoring_enabled(self, cluster):
+        mon_label = self._label(cluster, "monitoring_enabled", "")
+        # NOTE(mkjpryor) default of, like heat driver,
+        # as requires cinder and takes a while
+        return mon_label == "true"
+
+    def _get_kube_dash_enabled(self, cluster):
+        kube_dash_label = self._label(cluster, "kube_dashboard_enabled", "")
+        # NOTE(mkjpryor) default on, like the heat driver
+        return kube_dash_label != "false"
+
+    def _update_helm_release(self, context, cluster):
+        cluster_template = cluster.cluster_template
+        image_id, kube_version = self._get_image_details(
+            context, cluster_template.image_id
+        )
+        values = {
+            "kubernetesVersion": kube_version,
+            "machineImageId": image_id,
+            # TODO(johngarbutt): need to generate app creds
+            "cloudCredentialsSecretName": self._get_app_cred_name(cluster),
+            # TODO(johngarbutt): need to respect requested networks
+            "clusterNetworking": {
+                "internalNetwork": {
+                    "nodeCidr": self._label(
+                        cluster, "fixed_subnet_cidr", "10.0.0.0/24"
+                    ),
+                }
+            },
+            "apiServer": {
+                "enableLoadBalancer": True,
+                "loadBalancerProvider": self._label(
+                    cluster, "octavia_provider", "amphora"
+                ),
+            },
+            "controlPlane": {
+                "machineFlavor": cluster.master_flavor_id,
+                "machineCount": cluster.master_count,
+            },
+            "addons": {
+                "monitoring": {
+                    "enabled": self._get_monitoring_enabled(cluster)
+                },
+                "kubernetesDashboard": {
+                    "enabled": self._get_kube_dash_enabled(cluster)
+                },
+                # TODO(mkjpryor): can't enable ingress until code exists to
+                #                 remove the load balancer
+                "ingress": {"enabled": False},
+            },
+            "nodeGroups": [
+                {
+                    "name": self._sanitized_name(ng.name),
+                    "machineFlavor": ng.flavor_id,
+                    "machineCount": ng.node_count,
+                }
+                for ng in cluster.nodegroups
+                if ng.role != "master"
+            ],
+        }
+
+        if cluster_template.dns_nameserver:
+            dns_nameservers = cluster_template.dns_nameserver.split(",")
+            values["clusterNetworking"]["dnsNameservers"] = dns_nameservers
+
+        if cluster.keypair:
+            values["machineSSHKeyName"] = cluster.keypair
+
+        chart_version = self._get_chart_version(cluster)
+
+        self._helm_client.install_or_upgrade(
+            self._get_chart_release_name(cluster),
+            CONF.capi_helm.helm_chart_name,
+            values,
+            repo=CONF.capi_helm.helm_chart_repo,
+            version=chart_version,
+            namespace=self._namespace(cluster),
+        )
+
+    def _generate_release_name(self, cluster):
+        if cluster.stack_id:
+            return
+
+        # Make sure no duplicate names
+        # by generating 12 character random id
+        random_bit = short_id.generate_id()
+        base_name = self._sanitized_name(cluster.name)
+        # valid release names are 53 chars long
+        # and stack_id is 12 characters
+        # but we also use this to derive hostnames
+        trimmed_name = base_name[:30]
+        # Save the full name, so users can rename in the API
+        cluster.stack_id = f"{trimmed_name}-{random_bit}".lower()
+        # be sure to save this before we use it
+        cluster.save()
+
+    def _get_chart_release_name(self, cluster):
+        return cluster.stack_id
+
     def create_cluster(self, context, cluster, cluster_create_timeout):
-        raise NotImplementedError("don't support create yet")
+        LOG.info("Starting to create cluster %s", cluster.uuid)
+
+        # we generate this name (on the initial create call only)
+        # so we hit no issues with duplicate cluster names
+        # and it makes renaming clusters in the API possible
+        self._generate_release_name(cluster)
+
+        self._update_helm_release(context, cluster)
 
     def update_cluster(
         self, context, cluster, scale_manager=None, rollback=False
@@ -41,7 +213,15 @@ class Driver(driver.Driver):
         raise NotImplementedError("don't support update yet")
 
     def delete_cluster(self, context, cluster):
-        raise NotImplementedError("don't support delete yet")
+        LOG.info("Starting to delete cluster %s", cluster.uuid)
+        # Begin the deletion of the cluster resources by uninstalling the
+        # Helm release
+        # Note that this just marks the resources for deletion - it does not
+        # wait for the resources to be deleted
+        self._helm_client.uninstall_release(
+            self._get_chart_release_name(cluster),
+            namespace=self._namespace(cluster),
+        )
 
     def resize_cluster(
         self,

--- a/magnum_capi_helm/tests/test_driver.py
+++ b/magnum_capi_helm/tests/test_driver.py
@@ -1,20 +1,26 @@
-#    Licensed under the Apache License, Version 2.0 (the "License"); you may
-#    not use this file except in compliance with the License. You may obtain
-#    a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-#    License for the specific language governing permissions and limitations
-#    under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+from unittest import mock
 
+from magnum.common import exception
 from magnum import objects
 from magnum.tests.unit.db import base
 from magnum.tests.unit.objects import utils as obj_utils
 
+from magnum_capi_helm import conf
 from magnum_capi_helm import driver
+from magnum_capi_helm import helm
+
+CONF = conf.CONF
 
 
 class ClusterAPIDriverTest(base.DbTestCase):
@@ -26,7 +32,13 @@ class ClusterAPIDriverTest(base.DbTestCase):
             name="cluster_example_$A",
             master_flavor_id="flavor_small",
             flavor_id="flavor_medium",
+            stack_id="cluster-example-a-111111111111",
         )
+        # add in missing node group flavor
+        for ng in self.cluster_obj.nodegroups:
+            if ng.role != "master":
+                ng.flavor_id = "flavor_medium"
+                ng.save()
 
     def test_provides(self):
         self.assertEqual(
@@ -42,21 +54,208 @@ class ClusterAPIDriverTest(base.DbTestCase):
             self.cluster_obj,
         )
 
-    def test_create_cluster(self):
-        self.assertRaises(
-            NotImplementedError,
-            self.driver.create_cluster,
-            self.context,
-            self.cluster_obj,
-            cluster_create_timeout=10,
+    def test_namespace(self):
+        self.cluster_obj.project_id = "123-456F"
+
+        namespace = self.driver._namespace(self.cluster_obj)
+
+        self.assertEqual("magnum-123456f", namespace)
+
+    def test_label_return_default(self):
+        result = self.driver._label(self.cluster_obj, "foo", "bar")
+
+        self.assertEqual("bar", result)
+
+    def test_label_return_template(self):
+        self.cluster_obj.cluster_template.labels = dict(foo=42)
+
+        result = self.driver._label(self.cluster_obj, "foo", "bar")
+
+        self.assertEqual("42", result)
+
+    def test_label_return_cluster(self):
+        self.cluster_obj.labels = dict(foo=41)
+        self.cluster_obj.cluster_template.labels = dict(foo=42)
+
+        result = self.driver._label(self.cluster_obj, "foo", "bar")
+
+        self.assertEqual("41", result)
+
+    def test_sanitized_name_no_suffix(self):
+        self.assertEqual(
+            "123-456fab", self.driver._sanitized_name("123-456Fab")
         )
 
-    def test_delete_cluster(self):
-        self.assertRaises(
-            NotImplementedError,
-            self.driver.delete_cluster,
-            self.context,
-            self.cluster_obj,
+    def test_sanitized_name_with_suffix(self):
+        self.assertEqual(
+            "123-456-fab-1-asdf",
+            self.driver._sanitized_name("123-456_Fab!!_1!!", "asdf"),
+        )
+        self.assertEqual(
+            "123-456-fab-1-asdf",
+            self.driver._sanitized_name("123-456_Fab-1", "asdf"),
+        )
+
+    def test_get_kube_version_raises(self):
+        mock_image = mock.Mock()
+        mock_image.get.return_value = None
+        mock_image.id = "myid"
+
+        e = self.assertRaises(
+            exception.MagnumException,
+            self.driver._get_kube_version,
+            mock_image,
+        )
+
+        self.assertEqual(
+            "Image myid does not have a kube_version property.", str(e)
+        )
+        mock_image.get.assert_called_once_with("kube_version")
+
+    def test_get_kube_version_works(self):
+        mock_image = mock.Mock()
+        mock_image.get.return_value = "v1.27.9"
+
+        result = self.driver._get_kube_version(mock_image)
+
+        self.assertEqual("1.27.9", result)
+        mock_image.get.assert_called_once_with("kube_version")
+
+    @mock.patch("magnum.common.clients.OpenStackClients")
+    @mock.patch("magnum.api.utils.get_openstack_resource")
+    def test_get_image_details(self, mock_get, mock_osc):
+        mock_image = mock.Mock()
+        mock_image.get.return_value = "v1.27.9"
+        mock_image.id = "myid"
+        mock_get.return_value = mock_image
+
+        id, version = self.driver._get_image_details(
+            self.context, "myimagename"
+        )
+
+        self.assertEqual("1.27.9", version)
+        self.assertEqual("myid", id)
+        mock_image.get.assert_called_once_with("kube_version")
+        mock_get.assert_called_once_with(mock.ANY, "myimagename", "images")
+
+    def test_get_chart_release_name_lenght(self):
+        self.cluster_obj.stack_id = "foo"
+
+        result = self.driver._get_chart_release_name(self.cluster_obj)
+
+        self.assertEqual("foo", result)
+
+    def test_generate_release_name_skip(self):
+        self.cluster_obj.stack_id = "foo"
+        self.driver._generate_release_name(self.cluster_obj)
+        self.assertEqual("foo", self.cluster_obj.stack_id)
+
+    def test_generate_release_name_generates(self):
+        self.cluster_obj.stack_id = None
+        self.cluster_obj.name = "a" * 77
+
+        self.driver._generate_release_name(self.cluster_obj)
+        first = self.cluster_obj.stack_id
+
+        self.assertEqual(43, len(first))
+        self.assertTrue(self.cluster_obj.name[:30] in first)
+
+        self.cluster_obj.stack_id = None
+        self.driver._generate_release_name(self.cluster_obj)
+        second = self.cluster_obj.stack_id
+
+        self.assertNotEqual(first, second)
+        self.assertEqual(43, len(second))
+        self.assertTrue(self.cluster_obj.name[:30] in second)
+
+    def test_get_monitoring_enabled_from_template(self):
+        self.cluster_obj.cluster_template.labels["monitoring_enabled"] = "true"
+
+        result = self.driver._get_monitoring_enabled(self.cluster_obj)
+
+        self.assertTrue(result)
+
+    def test_get_kube_dash_enabled_from_template(self):
+        self.cluster_obj.cluster_template.labels[
+            "kube_dashboard_enabled"
+        ] = "false"
+
+        result = self.driver._get_kube_dash_enabled(self.cluster_obj)
+
+        self.assertFalse(result)
+
+    def test_get_chart_version_from_config(self):
+        version = self.driver._get_chart_version(self.cluster_obj)
+
+        self.assertEqual(CONF.capi_helm.default_helm_chart_version, version)
+
+    def test_get_chart_version_from_template(self):
+        self.cluster_obj.cluster_template.labels[
+            "capi_helm_chart_version"
+        ] = "1.42.0"
+
+        version = self.driver._get_chart_version(self.cluster_obj)
+
+        self.assertEqual("1.42.0", version)
+
+    @mock.patch.object(driver.Driver, "_get_image_details")
+    @mock.patch.object(helm.Client, "install_or_upgrade")
+    def test_create_cluster(
+        self,
+        mock_install,
+        mock_image,
+    ):
+        mock_image.return_value = ("imageid1", "1.27.4")
+
+        self.cluster_obj.keypair = "kp1"
+
+        self.driver.create_cluster(self.context, self.cluster_obj, 10)
+
+        app_cred_name = "cluster-example-a-111111111111-cloud-credentials"
+        mock_install.assert_called_once_with(
+            "cluster-example-a-111111111111",
+            "openstack-cluster",
+            {
+                "kubernetesVersion": "1.27.4",
+                "machineImageId": "imageid1",
+                "cloudCredentialsSecretName": app_cred_name,
+                "clusterNetworking": {
+                    "internalNetwork": {"nodeCidr": "10.0.0.0/24"},
+                    "dnsNameservers": ["8.8.1.1"],
+                },
+                "apiServer": {
+                    "enableLoadBalancer": True,
+                    "loadBalancerProvider": "amphora",
+                },
+                "controlPlane": {
+                    "machineFlavor": "flavor_small",
+                    "machineCount": 3,
+                },
+                "addons": {
+                    "monitoring": {"enabled": False},
+                    "kubernetesDashboard": {"enabled": True},
+                    "ingress": {"enabled": False},
+                },
+                "nodeGroups": [
+                    {
+                        "name": "test-worker",
+                        "machineFlavor": "flavor_medium",
+                        "machineCount": 3,
+                    }
+                ],
+                "machineSSHKeyName": "kp1",
+            },
+            repo=CONF.capi_helm.helm_chart_repo,
+            version=CONF.capi_helm.default_helm_chart_version,
+            namespace="magnum-fakeproject",
+        )
+
+    @mock.patch.object(helm.Client, "uninstall_release")
+    def test_delete_cluster(self, mock_uninstall):
+        self.driver.delete_cluster(self.context, self.cluster_obj)
+
+        mock_uninstall.assert_called_once_with(
+            "cluster-example-a-111111111111", namespace="magnum-fakeproject"
         )
 
     def test_update_cluster(self):


### PR DESCRIPTION
This adds the initial create and delete of clusters via the helm charts. Howerver, this references an app cred secret we have not yet created. We also do not yet monitor the progress of the create or delete, we just set the cluster into Error. Fixes for this will be in later patches.

Note we default to using the openstack_cluster chart from this repo:
https://stackhpc.github.io/capi-helm-charts

We hope this helm chart will eventually move into the ownership of the magnum project.

Users can modify the default helm chart values by creating their own charts, and changing the configuration to point to their own customized helm chart.

Taken from:
https://review.opendev.org/c/openstack/magnum/+/881453

Change-Id: I1c0c7e734788fe126a9cd173913150f7a9cca6fc