### PR TITLE
ClusterAPI: implement update_cluster_status

### DIFF
--- a/magnum_capi_helm/driver.py
+++ b/magnum_capi_helm/driver.py
@@ -44,7 +44,9 @@ class Driver(driver.Driver):
         return [
             {
                 "server_type": "vm",
-                "os": "ubuntu",
+                # NOTE(johngarbutt) we don't depend on a specific OS,
+                # we depend on kubeadm images with cloud-init
+                "os": "capi-kubeadm-cloudinit",
                 "coe": "kubernetes",
             },
         ]

--- a/magnum_capi_helm/kubernetes.py
+++ b/magnum_capi_helm/kubernetes.py
@@ -129,6 +129,33 @@ class Client(requests.Session):
     def apply_secret(self, secret_name, data, namespace):
         Secret(self).apply(secret_name, data, namespace)
 
+    def delete_all_secrets_by_label(self, label, value, namespace):
+        Secret(self).delete_all_by_label(label, value, namespace)
+
+    def get_capi_cluster(self, name, namespace):
+        return Cluster(self).fetch(name, namespace)
+
+    def get_kubeadm_control_plane(self, name, namespace):
+        return KubeadmControlPlane(self).fetch(name, namespace)
+
+    def get_machine_deployment(self, name, namespace):
+        return MachineDeployment(self).fetch(name, namespace)
+
+    def get_manifests_by_label(self, label, value, namespace):
+        return list(
+            Manifests(self).fetch_all_by_label(label, value, namespace)
+        )
+
+    def get_helm_releases_by_label(self, label, value, namespace):
+        return list(
+            HelmRelease(self).fetch_all_by_label(label, value, namespace)
+        )
+
+    def get_addons_by_label(self, label, value, namespace):
+        addons = list(self.get_manifests_by_label(label, value, namespace))
+        addons.extend(self.get_helm_releases_by_label(label, value, namespace))
+        return addons
+
 
 class Resource:
     def __init__(self, client):
@@ -153,6 +180,38 @@ class Resource:
             f"{self.plural_name}{path_name}"
         )
 
+    def fetch(self, name, namespace=None):
+        """Fetches specified object from the target Kubernetes cluster.
+
+        If the object is not found, None is returned.
+        """
+        assert self.namespaced == bool(namespace)
+        response = self.client.get(self.prepare_path(name, namespace))
+        if 200 <= response.status_code < 300:
+            return response.json()
+        elif response.status_code == 404:
+            return None
+        else:
+            response.raise_for_status()
+
+    def fetch_all_by_label(self, label, value, namespace=None):
+        """Fetches all objects with the specified label from cluster."""
+        assert self.namespaced == bool(namespace)
+        continue_token = ""
+        while True:
+            params = {"labelSelector": f"{label}={value}"}
+            if continue_token:
+                params["continue"] = continue_token
+            response = self.client.get(
+                self.prepare_path(namespace=namespace), params=params
+            )
+            response.raise_for_status()
+            response_data = response.json()
+            yield from response_data["items"]
+            continue_token = response_data["metadata"]["continue"]
+            if not continue_token:
+                break
+
     def apply(self, name, data=None, namespace=None):
         """Applies the given object to the target Kubernetes cluster."""
         assert self.namespaced == bool(namespace)
@@ -171,6 +230,15 @@ class Resource:
         response.raise_for_status()
         return response.json()
 
+    def delete_all_by_label(self, label, value, namespace=None):
+        """Deletes all objects with the specified label from cluster."""
+        assert self.namespaced == bool(namespace)
+        response = self.client.delete(
+            self.prepare_path(namespace=namespace),
+            params={"labelSelector": f"{label}={value}"},
+        )
+        response.raise_for_status()
+
 
 class Namespace(Resource):
     api_version = "v1"
@@ -179,3 +247,24 @@ class Namespace(Resource):
 
 class Secret(Resource):
     api_version = "v1"
+
+
+class Cluster(Resource):
+    api_version = "cluster.x-k8s.io/v1beta1"
+
+
+class MachineDeployment(Resource):
+    api_version = "cluster.x-k8s.io/v1beta1"
+
+
+class KubeadmControlPlane(Resource):
+    api_version = "controlplane.cluster.x-k8s.io/v1beta1"
+
+
+class Manifests(Resource):
+    api_version = "addons.stackhpc.com/v1alpha1"
+    plural_name = "manifests"
+
+
+class HelmRelease(Resource):
+    api_version = "addons.stackhpc.com/v1alpha1"

--- a/magnum_capi_helm/tests/common/test_app_creds.py
+++ b/magnum_capi_helm/tests/common/test_app_creds.py
@@ -12,6 +12,7 @@
 import collections
 from unittest import mock
 
+import keystoneauth1
 from magnum.common import clients
 from magnum.common import utils
 from magnum.tests.unit.db import base
@@ -106,3 +107,29 @@ clouds:
 """,
         }
         self.assertEqual(expected, app_cred)
+
+    @mock.patch.object(clients, "OpenStackClients")
+    def test_delete_app_cred(self, mock_client):
+        mock_app_cred = mock_client().keystone().client.application_credentials
+        mock_find = mock.MagicMock()
+        mock_app_cred.find.return_value = mock_find
+
+        app_creds.delete_app_cred("context", self.cluster_obj)
+
+        mock_find.delete.assert_called_once_with()
+        mock_app_cred.find.assert_called_once_with(
+            name=f"magnum-{self.cluster_obj.uuid}",
+            user="fake_user",
+        )
+
+    @mock.patch.object(clients, "OpenStackClients")
+    def test_delete_app_cred_not_found(self, mock_client):
+        mock_app_cred = mock_client().keystone().client.application_credentials
+        mock_app_cred.find.side_effect = keystoneauth1.exceptions.http.NotFound
+
+        app_creds.delete_app_cred("context", self.cluster_obj)
+
+        mock_app_cred.find.assert_called_once_with(
+            name=f"magnum-{self.cluster_obj.uuid}",
+            user="fake_user",
+        )

--- a/magnum_capi_helm/tests/test_driver.py
+++ b/magnum_capi_helm/tests/test_driver.py
@@ -12,7 +12,9 @@
 from unittest import mock
 
 from magnum.common import exception
+from magnum.drivers.common import k8s_monitor
 from magnum import objects
+from magnum.objects import fields
 from magnum.tests.unit.db import base
 from magnum.tests.unit.objects import utils as obj_utils
 
@@ -56,13 +58,767 @@ class ClusterAPIDriverTest(base.DbTestCase):
             self.driver.provides,
         )
 
-    def test_update_cluster_status(self):
-        self.assertRaises(
-            NotImplementedError,
-            self.driver.update_cluster_status,
-            self.context,
-            self.cluster_obj,
+    @mock.patch.object(driver.Driver, "_update_status_deleting")
+    @mock.patch.object(driver.Driver, "_update_status_updating")
+    @mock.patch.object(driver.Driver, "_update_all_nodegroups_status")
+    @mock.patch.object(driver.Driver, "_get_capi_cluster")
+    def test_update_cluster_status_creating(
+        self, mock_capi, mock_ng, mock_update, mock_delete
+    ):
+        mock_ng.return_value = True
+        mock_capi.return_value = {"spec": {}}
+        self.cluster_obj.status = fields.ClusterStatus.CREATE_IN_PROGRESS
+
+        self.driver.update_cluster_status(self.context, self.cluster_obj)
+
+        mock_ng.assert_called_once_with(self.cluster_obj)
+        mock_update.assert_not_called()
+        mock_delete.assert_not_called()
+
+    @mock.patch.object(driver.Driver, "_update_status_deleting")
+    @mock.patch.object(driver.Driver, "_update_status_updating")
+    @mock.patch.object(driver.Driver, "_update_all_nodegroups_status")
+    @mock.patch.object(driver.Driver, "_get_capi_cluster")
+    def test_update_cluster_status_creating_not_found(
+        self, mock_capi, mock_ng, mock_update, mock_delete
+    ):
+        mock_ng.return_value = True
+        mock_capi.return_value = None
+        self.cluster_obj.status = fields.ClusterStatus.CREATE_IN_PROGRESS
+
+        self.driver.update_cluster_status(self.context, self.cluster_obj)
+
+        mock_ng.assert_called_once_with(self.cluster_obj)
+        mock_update.assert_not_called()
+        mock_delete.assert_not_called()
+
+    @mock.patch.object(driver.Driver, "_update_status_deleting")
+    @mock.patch.object(driver.Driver, "_update_status_updating")
+    @mock.patch.object(driver.Driver, "_update_all_nodegroups_status")
+    @mock.patch.object(driver.Driver, "_get_capi_cluster")
+    def test_update_cluster_status_created(
+        self, mock_capi, mock_ng, mock_update, mock_delete
+    ):
+        mock_ng.return_value = False
+        mock_capi.return_value = {"spec": {}}
+        self.cluster_obj.status = fields.ClusterStatus.CREATE_IN_PROGRESS
+
+        self.driver.update_cluster_status(self.context, self.cluster_obj)
+
+        mock_ng.assert_called_once_with(self.cluster_obj)
+        mock_update.assert_called_once_with(self.cluster_obj, {"spec": {}})
+        mock_delete.assert_not_called()
+
+    @mock.patch.object(driver.Driver, "_update_status_deleting")
+    @mock.patch.object(driver.Driver, "_update_status_updating")
+    @mock.patch.object(driver.Driver, "_update_all_nodegroups_status")
+    @mock.patch.object(driver.Driver, "_get_capi_cluster")
+    def test_update_cluster_status_deleted(
+        self, mock_capi, mock_ng, mock_update, mock_delete
+    ):
+        mock_capi.return_value = None
+        self.cluster_obj.status = fields.ClusterStatus.DELETE_IN_PROGRESS
+
+        self.driver.update_cluster_status(self.context, self.cluster_obj)
+
+        mock_ng.assert_called_once_with(self.cluster_obj)
+        mock_update.assert_not_called()
+        mock_delete.assert_called_once_with(self.context, self.cluster_obj)
+
+    @mock.patch.object(driver.Driver, "_update_status_deleting")
+    @mock.patch.object(driver.Driver, "_update_status_updating")
+    @mock.patch.object(driver.Driver, "_update_all_nodegroups_status")
+    @mock.patch.object(driver.Driver, "_get_capi_cluster")
+    def test_update_cluster_status_deleting(
+        self, mock_capi, mock_ng, mock_update, mock_delete
+    ):
+        mock_capi.return_value = {"spec": {}}
+        self.cluster_obj.status = fields.ClusterStatus.DELETE_IN_PROGRESS
+
+        self.driver.update_cluster_status(self.context, self.cluster_obj)
+
+        mock_ng.assert_called_once_with(self.cluster_obj)
+        mock_update.assert_not_called()
+        mock_delete.assert_not_called()
+
+    @mock.patch.object(driver.Driver, "_update_status_deleting")
+    @mock.patch.object(driver.Driver, "_update_status_updating")
+    @mock.patch.object(driver.Driver, "_update_all_nodegroups_status")
+    @mock.patch.object(driver.Driver, "_get_capi_cluster")
+    def test_update_cluster_status_create_complete(
+        self, mock_capi, mock_ng, mock_update, mock_delete
+    ):
+        mock_capi.return_value = {"spec": {}}
+        self.cluster_obj.status = fields.ClusterStatus.CREATE_COMPLETE
+
+        self.driver.update_cluster_status(self.context, self.cluster_obj)
+
+        mock_ng.assert_called_once_with(self.cluster_obj)
+        mock_update.assert_not_called()
+        mock_delete.assert_not_called()
+
+    @mock.patch.object(driver.Driver, "_update_worker_nodegroup_status")
+    @mock.patch.object(driver.Driver, "_update_control_plane_nodegroup_status")
+    def test_update_all_nodegroups_status_not_in_progress(
+        self, mock_cp, mock_w
+    ):
+        control_plane = [
+            ng
+            for ng in self.cluster_obj.nodegroups
+            if ng.role == driver.NODE_GROUP_ROLE_CONTROLLER
+        ][0]
+        control_plane.status = fields.ClusterStatus.CREATE_COMPLETE
+        mock_cp.return_value = control_plane
+        mock_w.return_value = None
+
+        result = self.driver._update_all_nodegroups_status(self.cluster_obj)
+
+        self.assertFalse(result)
+        control_plane = [
+            ng
+            for ng in self.cluster_obj.nodegroups
+            if ng.role == driver.NODE_GROUP_ROLE_CONTROLLER
+        ][0]
+        mock_cp.assert_called_once_with(self.cluster_obj, mock.ANY)
+        self.assertEqual(
+            control_plane.obj_to_primitive(),
+            mock_cp.call_args_list[0][0][1].obj_to_primitive(),
         )
+        mock_w.assert_called_once_with(self.cluster_obj, mock.ANY)
+        worker = [
+            ng
+            for ng in self.cluster_obj.nodegroups
+            if ng.role != driver.NODE_GROUP_ROLE_CONTROLLER
+        ][0]
+        self.assertEqual(
+            worker.obj_to_primitive(),
+            mock_w.call_args_list[0][0][1].obj_to_primitive(),
+        )
+
+    @mock.patch.object(driver.Driver, "_update_worker_nodegroup_status")
+    @mock.patch.object(driver.Driver, "_update_control_plane_nodegroup_status")
+    def test_update_all_nodegroups_status_in_progress(self, mock_cp, mock_w):
+        control_plane = [
+            ng
+            for ng in self.cluster_obj.nodegroups
+            if ng.role == driver.NODE_GROUP_ROLE_CONTROLLER
+        ][0]
+        control_plane.status = fields.ClusterStatus.CREATE_IN_PROGRESS
+        mock_cp.return_value = control_plane
+        mock_w.return_value = None
+
+        result = self.driver._update_all_nodegroups_status(self.cluster_obj)
+
+        self.assertTrue(result)
+        mock_cp.assert_called_once_with(self.cluster_obj, mock.ANY)
+        mock_w.assert_called_once_with(self.cluster_obj, mock.ANY)
+
+    @mock.patch.object(driver.Driver, "_update_nodegroup_status")
+    @mock.patch.object(kubernetes.Client, "load")
+    def test_update_worker_nodegroup_status_empty(
+        self, mock_load, mock_update
+    ):
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_load.return_value = mock_client
+        nodegroup = mock.MagicMock()
+        nodegroup.name = "workers"
+        mock_client.get_machine_deployment.return_value = None
+
+        self.driver._update_worker_nodegroup_status(
+            self.cluster_obj, nodegroup
+        )
+
+        mock_client.get_machine_deployment.assert_called_once_with(
+            "cluster-example-a-111111111111-workers", "magnum-fakeproject"
+        )
+        mock_update.assert_called_once_with(
+            self.cluster_obj, mock.ANY, driver.NodeGroupState.NOT_PRESENT
+        )
+
+    @mock.patch.object(driver.Driver, "_update_nodegroup_status")
+    @mock.patch.object(kubernetes.Client, "load")
+    def test_update_worker_nodegroup_status_scaling_up(
+        self, mock_load, mock_update
+    ):
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_load.return_value = mock_client
+        nodegroup = mock.MagicMock()
+        nodegroup.name = "workers"
+        md = {"status": {"phase": "ScalingUp"}}
+        mock_client.get_machine_deployment.return_value = md
+
+        self.driver._update_worker_nodegroup_status(
+            self.cluster_obj, nodegroup
+        )
+
+        mock_client.get_machine_deployment.assert_called_once_with(
+            "cluster-example-a-111111111111-workers", "magnum-fakeproject"
+        )
+        mock_update.assert_called_once_with(
+            self.cluster_obj, mock.ANY, driver.NodeGroupState.PENDING
+        )
+
+    @mock.patch.object(driver.Driver, "_update_nodegroup_status")
+    @mock.patch.object(kubernetes.Client, "load")
+    def test_update_worker_nodegroup_status_failed(
+        self, mock_load, mock_update
+    ):
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_load.return_value = mock_client
+        nodegroup = mock.MagicMock()
+        nodegroup.name = "workers"
+        md = {"status": {"phase": "Failed"}}
+        mock_client.get_machine_deployment.return_value = md
+
+        self.driver._update_worker_nodegroup_status(
+            self.cluster_obj, nodegroup
+        )
+
+        mock_client.get_machine_deployment.assert_called_once_with(
+            "cluster-example-a-111111111111-workers", "magnum-fakeproject"
+        )
+        mock_update.assert_called_once_with(
+            self.cluster_obj, mock.ANY, driver.NodeGroupState.FAILED
+        )
+
+    @mock.patch.object(driver.Driver, "_update_nodegroup_status")
+    @mock.patch.object(kubernetes.Client, "load")
+    def test_update_worker_nodegroup_status_running(
+        self, mock_load, mock_update
+    ):
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_load.return_value = mock_client
+        nodegroup = mock.MagicMock()
+        nodegroup.name = "workers"
+        md = {"status": {"phase": "Running"}}
+        mock_client.get_machine_deployment.return_value = md
+
+        self.driver._update_worker_nodegroup_status(
+            self.cluster_obj, nodegroup
+        )
+
+        mock_client.get_machine_deployment.assert_called_once_with(
+            "cluster-example-a-111111111111-workers", "magnum-fakeproject"
+        )
+        mock_update.assert_called_once_with(
+            self.cluster_obj, mock.ANY, driver.NodeGroupState.READY
+        )
+
+    @mock.patch.object(driver.Driver, "_update_nodegroup_status")
+    @mock.patch.object(kubernetes.Client, "load")
+    def test_update_control_plane_nodegroup_status_empty(
+        self, mock_load, mock_update
+    ):
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_load.return_value = mock_client
+        nodegroup = mock.MagicMock()
+        nodegroup.name = "masters"
+        mock_client.get_kubeadm_control_plane.return_value = None
+
+        self.driver._update_control_plane_nodegroup_status(
+            self.cluster_obj, nodegroup
+        )
+
+        mock_client.get_kubeadm_control_plane.assert_called_once_with(
+            "cluster-example-a-111111111111-control-plane",
+            "magnum-fakeproject",
+        )
+        mock_update.assert_called_once_with(
+            self.cluster_obj, mock.ANY, driver.NodeGroupState.NOT_PRESENT
+        )
+
+    @mock.patch.object(driver.Driver, "_update_nodegroup_status")
+    @mock.patch.object(kubernetes.Client, "load")
+    def test_update_control_plane_nodegroup_status_condition_false(
+        self, mock_load, mock_update
+    ):
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_load.return_value = mock_client
+        nodegroup = mock.MagicMock()
+        nodegroup.name = "masters"
+        kcp = {
+            "spec": {
+                "replicas": 3,
+            },
+            "status": {
+                "conditions": [
+                    {"type": "MachinesReady", "status": "True"},
+                    {"type": "Ready", "status": "True"},
+                    {"type": "EtcdClusterHealthy", "status": "True"},
+                    {
+                        "type": "ControlPlaneComponentsHealthy",
+                        "status": "False",
+                    },
+                ],
+                "replicas": 3,
+                "updatedReplicas": 3,
+                "readyReplicas": 3,
+            },
+        }
+        mock_client.get_kubeadm_control_plane.return_value = kcp
+
+        self.driver._update_control_plane_nodegroup_status(
+            self.cluster_obj, nodegroup
+        )
+
+        mock_client.get_kubeadm_control_plane.assert_called_once_with(
+            "cluster-example-a-111111111111-control-plane",
+            "magnum-fakeproject",
+        )
+        mock_update.assert_called_once_with(
+            self.cluster_obj, mock.ANY, driver.NodeGroupState.PENDING
+        )
+
+    @mock.patch.object(driver.Driver, "_update_nodegroup_status")
+    @mock.patch.object(kubernetes.Client, "load")
+    def test_update_control_plane_nodegroup_status_mismatched_replicas(
+        self, mock_load, mock_update
+    ):
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_load.return_value = mock_client
+        nodegroup = mock.MagicMock()
+        nodegroup.name = "masters"
+        kcp = {
+            "spec": {
+                "replicas": 3,
+            },
+            "status": {
+                "conditions": [
+                    {"type": "MachinesReady", "status": "True"},
+                    {"type": "Ready", "status": "True"},
+                    {"type": "EtcdClusterHealthy", "status": "True"},
+                    {
+                        "type": "ControlPlaneComponentsHealthy",
+                        "status": "True",
+                    },
+                ],
+                "replicas": 3,
+                "updatedReplicas": 2,
+                "readyReplicas": 2,
+            },
+        }
+        mock_client.get_kubeadm_control_plane.return_value = kcp
+
+        self.driver._update_control_plane_nodegroup_status(
+            self.cluster_obj, nodegroup
+        )
+
+        mock_client.get_kubeadm_control_plane.assert_called_once_with(
+            "cluster-example-a-111111111111-control-plane",
+            "magnum-fakeproject",
+        )
+        mock_update.assert_called_once_with(
+            self.cluster_obj, mock.ANY, driver.NodeGroupState.PENDING
+        )
+
+    @mock.patch.object(driver.Driver, "_update_nodegroup_status")
+    @mock.patch.object(kubernetes.Client, "load")
+    def test_update_control_plane_nodegroup_status_ready(
+        self, mock_load, mock_update
+    ):
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_load.return_value = mock_client
+        nodegroup = mock.MagicMock()
+        nodegroup.name = "masters"
+        kcp = {
+            "spec": {
+                "replicas": 3,
+            },
+            "status": {
+                "conditions": [
+                    {"type": "MachinesReady", "status": "True"},
+                    {"type": "Ready", "status": "True"},
+                    {"type": "EtcdClusterHealthy", "status": "True"},
+                    {
+                        "type": "ControlPlaneComponentsHealthy",
+                        "status": "True",
+                    },
+                ],
+                "replicas": 3,
+                "updatedReplicas": 3,
+                "readyReplicas": 3,
+            },
+        }
+        mock_client.get_kubeadm_control_plane.return_value = kcp
+
+        self.driver._update_control_plane_nodegroup_status(
+            self.cluster_obj, nodegroup
+        )
+
+        mock_client.get_kubeadm_control_plane.assert_called_once_with(
+            "cluster-example-a-111111111111-control-plane",
+            "magnum-fakeproject",
+        )
+        mock_update.assert_called_once_with(
+            self.cluster_obj, mock.ANY, driver.NodeGroupState.READY
+        )
+
+    @mock.patch.object(k8s_monitor, "K8sMonitor")
+    def test_get_monitor(self, mock_mon):
+        self.driver.get_monitor(self.context, self.cluster_obj)
+        mock_mon.assert_called_once_with(self.context, self.cluster_obj)
+
+    @mock.patch.object(kubernetes.Client, "load")
+    def test_get_capi_cluster(self, mock_load):
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_load.return_value = mock_client
+
+        self.driver._get_capi_cluster(self.cluster_obj)
+
+        mock_client.get_capi_cluster.assert_called_once_with(
+            "cluster-example-a-111111111111", "magnum-fakeproject"
+        )
+
+    @mock.patch.object(app_creds, "delete_app_cred")
+    @mock.patch.object(kubernetes.Client, "load")
+    def test_update_status_deleting(self, mock_load, mock_delete):
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_load.return_value = mock_client
+
+        self.driver._update_status_deleting(self.context, self.cluster_obj)
+
+        self.assertEqual("DELETE_COMPLETE", self.cluster_obj.status)
+        mock_delete.assert_called_once_with(self.context, self.cluster_obj)
+        mock_client.delete_all_secrets_by_label.assert_called_once_with(
+            "magnum.openstack.org/cluster-uuid",
+            self.cluster_obj.uuid,
+            "magnum-fakeproject",
+        )
+
+    def test_update_status_updating_not_ready(self):
+        self.cluster_obj.status = fields.ClusterStatus.CREATE_IN_PROGRESS
+        capi_cluster = {}
+
+        self.driver._update_status_updating(self.cluster_obj, capi_cluster)
+
+        self.assertEqual(
+            fields.ClusterStatus.CREATE_IN_PROGRESS, self.cluster_obj.status
+        )
+
+    @mock.patch.object(kubernetes.Client, "load")
+    def test_update_status_updating_condition_false(self, mock_load):
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_client.get_addons_by_label.return_value = []
+        mock_load.return_value = mock_client
+
+        self.cluster_obj.status = fields.ClusterStatus.CREATE_IN_PROGRESS
+        capi_cluster = {
+            "status": {
+                "conditions": [
+                    dict(type="InfrastructureReady", status="True"),
+                    dict(type="ControlPlaneReady", status="True"),
+                    dict(type="Ready", status="False"),
+                ]
+            }
+        }
+
+        self.driver._update_status_updating(self.cluster_obj, capi_cluster)
+
+        self.assertEqual(
+            fields.ClusterStatus.CREATE_IN_PROGRESS, self.cluster_obj.status
+        )
+
+    @mock.patch.object(kubernetes.Client, "load")
+    def test_update_status_updating_ready_created(self, mock_load):
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_client.get_addons_by_label.return_value = []
+        mock_load.return_value = mock_client
+
+        self.cluster_obj.status = fields.ClusterStatus.CREATE_IN_PROGRESS
+        capi_cluster = {
+            "status": {
+                "conditions": [
+                    dict(type="InfrastructureReady", status="True"),
+                    dict(type="ControlPlaneReady", status="True"),
+                    dict(type="Ready", status="True"),
+                ]
+            }
+        }
+
+        self.driver._update_status_updating(self.cluster_obj, capi_cluster)
+
+        self.assertEqual(
+            fields.ClusterStatus.CREATE_COMPLETE, self.cluster_obj.status
+        )
+
+    @mock.patch.object(kubernetes.Client, "load")
+    def test_update_status_updating_addons_unknown(self, mock_load):
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_client.get_addons_by_label.return_value = [
+            {
+                "metadata": {"name": "cni"},
+                "status": {},
+            },
+            {
+                "metadata": {"name": "monitoring"},
+                "status": {},
+            },
+        ]
+        mock_load.return_value = mock_client
+
+        self.cluster_obj.status = fields.ClusterStatus.CREATE_IN_PROGRESS
+        capi_cluster = {
+            "status": {
+                "conditions": [
+                    dict(type="InfrastructureReady", status="True"),
+                    dict(type="ControlPlaneReady", status="True"),
+                    dict(type="Ready", status="True"),
+                ]
+            }
+        }
+
+        self.driver._update_status_updating(self.cluster_obj, capi_cluster)
+
+        self.assertEqual(
+            fields.ClusterStatus.CREATE_IN_PROGRESS, self.cluster_obj.status
+        )
+
+    @mock.patch.object(kubernetes.Client, "load")
+    def test_update_status_updating_addons_installing(self, mock_load):
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_client.get_addons_by_label.return_value = [
+            {
+                "metadata": {"name": "cni"},
+                "status": {"phase": "Deployed"},
+            },
+            {
+                "metadata": {"name": "monitoring"},
+                "status": {"phase": "Installing"},
+            },
+        ]
+        mock_load.return_value = mock_client
+
+        self.cluster_obj.status = fields.ClusterStatus.CREATE_IN_PROGRESS
+        capi_cluster = {
+            "status": {
+                "conditions": [
+                    dict(type="InfrastructureReady", status="True"),
+                    dict(type="ControlPlaneReady", status="True"),
+                    dict(type="Ready", status="True"),
+                ]
+            }
+        }
+
+        self.driver._update_status_updating(self.cluster_obj, capi_cluster)
+
+        self.assertEqual(
+            fields.ClusterStatus.CREATE_IN_PROGRESS, self.cluster_obj.status
+        )
+
+    @mock.patch.object(kubernetes.Client, "load")
+    def test_update_status_updating_addons_deployed(self, mock_load):
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_client.get_addons_by_label.return_value = [
+            {
+                "metadata": {"name": "cni"},
+                "status": {"phase": "Deployed"},
+            },
+            {
+                "metadata": {"name": "monitoring"},
+                "status": {"phase": "Deployed"},
+            },
+        ]
+        mock_load.return_value = mock_client
+
+        self.cluster_obj.status = fields.ClusterStatus.CREATE_IN_PROGRESS
+        capi_cluster = {
+            "status": {
+                "conditions": [
+                    dict(type="InfrastructureReady", status="True"),
+                    dict(type="ControlPlaneReady", status="True"),
+                    dict(type="Ready", status="True"),
+                ]
+            }
+        }
+
+        self.driver._update_status_updating(self.cluster_obj, capi_cluster)
+
+        self.assertEqual(
+            fields.ClusterStatus.CREATE_COMPLETE, self.cluster_obj.status
+        )
+
+    @mock.patch.object(kubernetes.Client, "load")
+    def test_update_status_updating_addons_failed(self, mock_load):
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_client.get_addons_by_label.return_value = [
+            {
+                "metadata": {"name": "cni"},
+                "status": {"phase": "Deployed"},
+            },
+            {
+                "metadata": {"name": "monitoring"},
+                "status": {"phase": "Failed"},
+            },
+        ]
+        mock_load.return_value = mock_client
+
+        self.cluster_obj.status = fields.ClusterStatus.CREATE_IN_PROGRESS
+        capi_cluster = {
+            "status": {
+                "conditions": [
+                    dict(type="InfrastructureReady", status="True"),
+                    dict(type="ControlPlaneReady", status="True"),
+                    dict(type="Ready", status="True"),
+                ]
+            }
+        }
+
+        self.driver._update_status_updating(self.cluster_obj, capi_cluster)
+
+        self.assertEqual(
+            fields.ClusterStatus.CREATE_FAILED, self.cluster_obj.status
+        )
+
+    @mock.patch.object(kubernetes.Client, "load")
+    def test_update_status_updating_ready_updated(self, mock_load):
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_client.get_addons_by_label.return_value = []
+        mock_load.return_value = mock_client
+
+        self.cluster_obj.status = fields.ClusterStatus.UPDATE_IN_PROGRESS
+        capi_cluster = {
+            "status": {
+                "conditions": [
+                    dict(type="InfrastructureReady", status="True"),
+                    dict(type="ControlPlaneReady", status="True"),
+                    dict(type="Ready", status="True"),
+                ]
+            }
+        }
+
+        self.driver._update_status_updating(self.cluster_obj, capi_cluster)
+
+        self.assertEqual(
+            fields.ClusterStatus.UPDATE_COMPLETE, self.cluster_obj.status
+        )
+
+    def test_update_cluster_api_address(self):
+        capi_cluster = {
+            "spec": {"controlPlaneEndpoint": {"host": "foo", "port": 6443}}
+        }
+
+        self.driver._update_cluster_api_address(self.cluster_obj, capi_cluster)
+
+        self.assertEqual("https://foo:6443", self.cluster_obj.api_address)
+
+    def test_update_cluster_api_address_skip(self):
+        self.cluster_obj.api_address = "asdf"
+        capi_cluster = {"spec": {"foo": "bar"}}
+
+        self.driver._update_cluster_api_address(self.cluster_obj, capi_cluster)
+
+        self.assertEqual("asdf", self.cluster_obj.api_address)
+
+    def test_update_cluster_api_address_skip_on_delete(self):
+        self.cluster_obj.status = fields.ClusterStatus.DELETE_IN_PROGRESS
+        self.cluster_obj.api_address = "asdf"
+        capi_cluster = {
+            "spec": {"controlPlaneEndpoint": {"host": "foo", "port": 6443}}
+        }
+
+        self.driver._update_cluster_api_address(self.cluster_obj, capi_cluster)
+
+        self.assertEqual("asdf", self.cluster_obj.api_address)
+
+    def test_update_nodegroup_status_create_complete(self):
+        nodegroup = obj_utils.create_test_nodegroup(self.context)
+        nodegroup.status = fields.ClusterStatus.CREATE_IN_PROGRESS
+
+        updated = self.driver._update_nodegroup_status(
+            self.cluster_obj, nodegroup, driver.NodeGroupState.READY
+        )
+
+        self.assertEqual(fields.ClusterStatus.CREATE_COMPLETE, updated.status)
+
+    def test_update_nodegroup_status_update_complete(self):
+        nodegroup = obj_utils.create_test_nodegroup(self.context)
+        nodegroup.status = fields.ClusterStatus.UPDATE_IN_PROGRESS
+
+        updated = self.driver._update_nodegroup_status(
+            self.cluster_obj, nodegroup, driver.NodeGroupState.READY
+        )
+
+        self.assertEqual(fields.ClusterStatus.UPDATE_COMPLETE, updated.status)
+
+    def test_update_nodegroup_status_create_failed(self):
+        nodegroup = obj_utils.create_test_nodegroup(self.context)
+        nodegroup.status = fields.ClusterStatus.CREATE_IN_PROGRESS
+
+        updated = self.driver._update_nodegroup_status(
+            self.cluster_obj, nodegroup, driver.NodeGroupState.FAILED
+        )
+
+        self.assertEqual(fields.ClusterStatus.CREATE_FAILED, updated.status)
+
+    def test_update_nodegroup_status_update_failed(self):
+        nodegroup = obj_utils.create_test_nodegroup(self.context)
+        nodegroup.status = fields.ClusterStatus.UPDATE_IN_PROGRESS
+
+        updated = self.driver._update_nodegroup_status(
+            self.cluster_obj, nodegroup, driver.NodeGroupState.FAILED
+        )
+
+        self.assertEqual(fields.ClusterStatus.UPDATE_FAILED, updated.status)
+
+    def test_update_nodegroup_status_create_in_progress(self):
+        nodegroup = obj_utils.create_test_nodegroup(self.context)
+        nodegroup.status = fields.ClusterStatus.CREATE_IN_PROGRESS
+
+        updated = self.driver._update_nodegroup_status(
+            self.cluster_obj, nodegroup, driver.NodeGroupState.PENDING
+        )
+
+        self.assertEqual(
+            fields.ClusterStatus.CREATE_IN_PROGRESS, updated.status
+        )
+
+    def test_update_nodegroup_status_delete_in_progress(self):
+        nodegroup = obj_utils.create_test_nodegroup(self.context)
+        nodegroup.status = fields.ClusterStatus.DELETE_IN_PROGRESS
+
+        updated = self.driver._update_nodegroup_status(
+            self.cluster_obj, nodegroup, driver.NodeGroupState.PENDING
+        )
+
+        self.assertEqual(
+            fields.ClusterStatus.DELETE_IN_PROGRESS, updated.status
+        )
+        self.assertEqual(nodegroup.as_dict(), updated.as_dict())
+
+    def test_update_nodegroup_creating_but_not_found(self):
+        nodegroup = obj_utils.create_test_nodegroup(self.context)
+        nodegroup.status = fields.ClusterStatus.CREATE_IN_PROGRESS
+
+        updated = self.driver._update_nodegroup_status(
+            self.cluster_obj, nodegroup, driver.NodeGroupState.NOT_PRESENT
+        )
+
+        self.assertEqual(
+            fields.ClusterStatus.CREATE_IN_PROGRESS, updated.status
+        )
+
+    def test_update_nodegroup_status_delete_return_none(self):
+        nodegroup = obj_utils.create_test_nodegroup(self.context)
+        nodegroup.status = fields.ClusterStatus.DELETE_IN_PROGRESS
+
+        result = self.driver._update_nodegroup_status(
+            self.cluster_obj, nodegroup, driver.NodeGroupState.NOT_PRESENT
+        )
+
+        self.assertIsNone(result)
+
+    def test_update_nodegroup_status_delete_unexpected_state(self):
+        nodegroup = obj_utils.create_test_nodegroup(self.context)
+        nodegroup.status = fields.ClusterStatus.ROLLBACK_IN_PROGRESS
+
+        updated = self.driver._update_nodegroup_status(
+            self.cluster_obj, nodegroup, driver.NodeGroupState.NOT_PRESENT
+        )
+
+        self.assertEqual(
+            fields.ClusterStatus.ROLLBACK_IN_PROGRESS, updated.status
+        )
+        self.assertEqual(nodegroup.as_dict(), updated.as_dict())
 
     def test_namespace(self):
         self.cluster_obj.project_id = "123-456F"
@@ -262,6 +1018,133 @@ class ClusterAPIDriverTest(base.DbTestCase):
                     }
                 ],
                 "machineSSHKeyName": "kp1",
+            },
+            repo=CONF.capi_helm.helm_chart_repo,
+            version=CONF.capi_helm.default_helm_chart_version,
+            namespace="magnum-fakeproject",
+        )
+        mock_client.ensure_namespace.assert_called_once_with(
+            "magnum-fakeproject"
+        )
+        mock_appcred.assert_called_once_with(self.context, self.cluster_obj)
+        mock_certs.assert_called_once_with(self.context, self.cluster_obj)
+
+    @mock.patch.object(driver.Driver, "_ensure_certificate_secrets")
+    @mock.patch.object(driver.Driver, "_create_appcred_secret")
+    @mock.patch.object(kubernetes.Client, "load")
+    @mock.patch.object(driver.Driver, "_get_image_details")
+    @mock.patch.object(helm.Client, "install_or_upgrade")
+    def test_create_cluster_no_dns(
+        self,
+        mock_install,
+        mock_image,
+        mock_load,
+        mock_appcred,
+        mock_certs,
+    ):
+        mock_image.return_value = ("imageid1", "1.27.4")
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_load.return_value = mock_client
+        self.cluster_obj.cluster_template.dns_nameserver = ""
+        self.cluster_obj.keypair = "kp1"
+
+        self.driver.create_cluster(self.context, self.cluster_obj, 10)
+
+        app_cred_name = "cluster-example-a-111111111111-cloud-credentials"
+        mock_install.assert_called_once_with(
+            "cluster-example-a-111111111111",
+            "openstack-cluster",
+            {
+                "kubernetesVersion": "1.27.4",
+                "machineImageId": "imageid1",
+                "cloudCredentialsSecretName": app_cred_name,
+                "clusterNetworking": {
+                    "internalNetwork": {"nodeCidr": "10.0.0.0/24"},
+                },
+                "apiServer": {
+                    "enableLoadBalancer": True,
+                    "loadBalancerProvider": "amphora",
+                },
+                "controlPlane": {
+                    "machineFlavor": "flavor_small",
+                    "machineCount": 3,
+                },
+                "addons": {
+                    "monitoring": {"enabled": False},
+                    "kubernetesDashboard": {"enabled": True},
+                    "ingress": {"enabled": False},
+                },
+                "nodeGroups": [
+                    {
+                        "name": "test-worker",
+                        "machineFlavor": "flavor_medium",
+                        "machineCount": 3,
+                    }
+                ],
+                "machineSSHKeyName": "kp1",
+            },
+            repo=CONF.capi_helm.helm_chart_repo,
+            version=CONF.capi_helm.default_helm_chart_version,
+            namespace="magnum-fakeproject",
+        )
+        mock_client.ensure_namespace.assert_called_once_with(
+            "magnum-fakeproject"
+        )
+        mock_appcred.assert_called_once_with(self.context, self.cluster_obj)
+        mock_certs.assert_called_once_with(self.context, self.cluster_obj)
+
+    @mock.patch.object(driver.Driver, "_ensure_certificate_secrets")
+    @mock.patch.object(driver.Driver, "_create_appcred_secret")
+    @mock.patch.object(kubernetes.Client, "load")
+    @mock.patch.object(driver.Driver, "_get_image_details")
+    @mock.patch.object(helm.Client, "install_or_upgrade")
+    def test_create_cluster_no_keypair(
+        self,
+        mock_install,
+        mock_image,
+        mock_load,
+        mock_appcred,
+        mock_certs,
+    ):
+        mock_image.return_value = ("imageid1", "1.27.4")
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_load.return_value = mock_client
+        self.cluster_obj.keypair = ""
+
+        self.driver.create_cluster(self.context, self.cluster_obj, 10)
+
+        app_cred_name = "cluster-example-a-111111111111-cloud-credentials"
+        mock_install.assert_called_once_with(
+            "cluster-example-a-111111111111",
+            "openstack-cluster",
+            {
+                "kubernetesVersion": "1.27.4",
+                "machineImageId": "imageid1",
+                "cloudCredentialsSecretName": app_cred_name,
+                "clusterNetworking": {
+                    "internalNetwork": {"nodeCidr": "10.0.0.0/24"},
+                    "dnsNameservers": ["8.8.1.1"],
+                },
+                "apiServer": {
+                    "enableLoadBalancer": True,
+                    "loadBalancerProvider": "amphora",
+                },
+                "controlPlane": {
+                    "machineFlavor": "flavor_small",
+                    "machineCount": 3,
+                },
+                "addons": {
+                    "monitoring": {"enabled": False},
+                    "kubernetesDashboard": {"enabled": True},
+                    "ingress": {"enabled": False},
+                },
+                "nodeGroups": [
+                    {
+                        "name": "test-worker",
+                        "machineFlavor": "flavor_medium",
+                        "machineCount": 3,
+                    }
+                ],
             },
             repo=CONF.capi_helm.helm_chart_repo,
             version=CONF.capi_helm.default_helm_chart_version,

--- a/magnum_capi_helm/tests/test_driver.py
+++ b/magnum_capi_helm/tests/test_driver.py
@@ -46,7 +46,13 @@ class ClusterAPIDriverTest(base.DbTestCase):
 
     def test_provides(self):
         self.assertEqual(
-            [{"server_type": "vm", "os": "ubuntu", "coe": "kubernetes"}],
+            [
+                {
+                    "server_type": "vm",
+                    "os": "capi-kubeadm-cloudinit",
+                    "coe": "kubernetes",
+                }
+            ],
             self.driver.provides,
         )
 

--- a/magnum_capi_helm/tests/test_kubernetes.py
+++ b/magnum_capi_helm/tests/test_kubernetes.py
@@ -160,3 +160,267 @@ class TestKubernetesClient(base.TestCase):
             headers={"Content-Type": "application/apply-patch+yaml"},
             params={"fieldManager": "magnum", "force": "true"},
         )
+
+    @mock.patch.object(requests.Session, "request")
+    def test_delete_all_secrets_by_label(self, mock_request):
+        client = kubernetes.Client(TEST_KUBECONFIG)
+        mock_response = mock.MagicMock()
+        mock_request.return_value = mock_response
+
+        client.delete_all_secrets_by_label("label", "cluster1", "ns1")
+
+        mock_request.assert_called_once_with(
+            "DELETE",
+            "https://test:6443/api/v1/namespaces/ns1/secrets",
+            params={"labelSelector": "label=cluster1"},
+        )
+        mock_response.raise_for_status.assert_called_once_with()
+
+    @mock.patch.object(requests.Session, "request")
+    def test_get_capi_cluster_found(self, mock_request):
+        client = kubernetes.Client(TEST_KUBECONFIG)
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = "mock_json"
+        mock_request.return_value = mock_response
+
+        cluster = client.get_capi_cluster("name", "ns1")
+
+        mock_request.assert_called_once_with(
+            "GET",
+            (
+                "https://test:6443/apis/cluster.x-k8s.io/"
+                "v1beta1/namespaces/ns1/clusters/name"
+            ),
+            allow_redirects=True,
+        )
+        self.assertEqual("mock_json", cluster)
+
+    @mock.patch.object(requests.Session, "request")
+    def test_get_capi_cluster_not_found(self, mock_request):
+        client = kubernetes.Client(TEST_KUBECONFIG)
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 404
+        mock_request.return_value = mock_response
+
+        cluster = client.get_capi_cluster("name", "ns1")
+
+        self.assertIsNone(cluster)
+
+    @mock.patch.object(requests.Session, "request")
+    def test_get_capi_cluster_error(self, mock_request):
+        client = kubernetes.Client(TEST_KUBECONFIG)
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 500
+        mock_response.raise_for_status.side_effect = requests.HTTPError
+        mock_request.return_value = mock_response
+
+        self.assertRaises(
+            requests.HTTPError, client.get_capi_cluster, "name", "ns1"
+        )
+
+    @mock.patch.object(requests.Session, "request")
+    def test_get_kubeadm_control_plane_found(self, mock_request):
+        client = kubernetes.Client(TEST_KUBECONFIG)
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = "mock_json"
+        mock_request.return_value = mock_response
+
+        cluster = client.get_kubeadm_control_plane("name", "ns1")
+
+        mock_request.assert_called_once_with(
+            "GET",
+            (
+                "https://test:6443/apis/controlplane.cluster.x-k8s.io/"
+                "v1beta1/namespaces/ns1/kubeadmcontrolplanes/name"
+            ),
+            allow_redirects=True,
+        )
+        self.assertEqual("mock_json", cluster)
+
+    @mock.patch.object(requests.Session, "request")
+    def test_get_machine_deployment_found(self, mock_request):
+        client = kubernetes.Client(TEST_KUBECONFIG)
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = "mock_json"
+        mock_request.return_value = mock_response
+
+        cluster = client.get_machine_deployment("name", "ns1")
+
+        mock_request.assert_called_once_with(
+            "GET",
+            (
+                "https://test:6443/apis/cluster.x-k8s.io/"
+                "v1beta1/namespaces/ns1/machinedeployments/name"
+            ),
+            allow_redirects=True,
+        )
+        self.assertEqual("mock_json", cluster)
+
+    @mock.patch.object(requests.Session, "request")
+    def test_get_manifests_by_label_found(self, mock_request):
+        items = [
+            {
+                "kind": "Manifests",
+                "metadata": {"name": f"manifests{idx}", "namespace": "ns1"},
+            }
+            for idx in range(5)
+        ]
+
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "metadata": {
+                "continue": "",
+            },
+            "items": items,
+        }
+        mock_request.return_value = mock_response
+
+        client = kubernetes.Client(TEST_KUBECONFIG)
+        manifests = client.get_manifests_by_label("label", "cluster1", "ns1")
+
+        mock_request.assert_called_once_with(
+            "GET",
+            (
+                "https://test:6443/apis/addons.stackhpc.com/"
+                "v1alpha1/namespaces/ns1/manifests"
+            ),
+            params={"labelSelector": "label=cluster1"},
+            allow_redirects=True,
+        )
+        self.assertEqual(items, manifests)
+
+    @mock.patch.object(requests.Session, "request")
+    def test_get_helm_releases_by_label_found(self, mock_request):
+        items = [
+            {
+                "kind": "HelmRelease",
+                "metadata": {"name": f"helmrelease{idx}", "namespace": "ns1"},
+            }
+            for idx in range(5)
+        ]
+
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "metadata": {
+                "continue": "",
+            },
+            "items": items,
+        }
+        mock_request.return_value = mock_response
+
+        client = kubernetes.Client(TEST_KUBECONFIG)
+        helm_releases = client.get_helm_releases_by_label(
+            "label", "cluster1", "ns1"
+        )
+
+        mock_request.assert_called_once_with(
+            "GET",
+            (
+                "https://test:6443/apis/addons.stackhpc.com/"
+                "v1alpha1/namespaces/ns1/helmreleases"
+            ),
+            params={"labelSelector": "label=cluster1"},
+            allow_redirects=True,
+        )
+        self.assertEqual(items, helm_releases)
+
+    @mock.patch.object(requests.Session, "request")
+    def test_get_helm_releases_by_label_multipage(self, mock_request):
+        items = [
+            {
+                "kind": "HelmRelease",
+                "metadata": {"name": f"helmrelease{idx}", "namespace": "ns1"},
+            }
+            for idx in range(10)
+        ]
+
+        mock_response_page1 = mock.Mock()
+        mock_response_page1.raise_for_status.return_value = None
+        mock_response_page1.json.return_value = {
+            "metadata": {
+                "continue": "continuetoken",
+            },
+            "items": items[:5],
+        }
+        mock_response_page2 = mock.Mock()
+        mock_response_page2.raise_for_status.return_value = None
+        mock_response_page2.json.return_value = {
+            "metadata": {
+                "continue": "",
+            },
+            "items": items[5:],
+        }
+        mock_request.side_effect = [
+            mock_response_page1,
+            mock_response_page2,
+        ]
+
+        client = kubernetes.Client(TEST_KUBECONFIG)
+        helm_releases = client.get_helm_releases_by_label(
+            "label", "cluster1", "ns1"
+        )
+
+        self.assertEqual(mock_request.call_count, 2)
+        mock_request.assert_has_calls(
+            [
+                mock.call(
+                    "GET",
+                    (
+                        "https://test:6443/apis/addons.stackhpc.com/"
+                        "v1alpha1/namespaces/ns1/helmreleases"
+                    ),
+                    params={"labelSelector": "label=cluster1"},
+                    allow_redirects=True,
+                ),
+                mock.call(
+                    "GET",
+                    (
+                        "https://test:6443/apis/addons.stackhpc.com/"
+                        "v1alpha1/namespaces/ns1/helmreleases"
+                    ),
+                    params={
+                        "labelSelector": "label=cluster1",
+                        "continue": "continuetoken",
+                    },
+                    allow_redirects=True,
+                ),
+            ]
+        )
+        self.assertEqual(items, helm_releases)
+
+    @mock.patch.object(kubernetes.Client, "get_helm_releases_by_label")
+    @mock.patch.object(kubernetes.Client, "get_manifests_by_label")
+    def test_get_addons_by_label_found(
+        self, mock_get_manifests, mock_get_helm_releases
+    ):
+        manifests = [
+            {
+                "kind": "Manifests",
+                "metadata": {"name": f"manifests{idx}", "namespace": "ns1"},
+            }
+            for idx in range(5)
+        ]
+        helm_releases = [
+            {
+                "kind": "HelmRelease",
+                "metadata": {"name": f"helmrelease{idx}", "namespace": "ns1"},
+            }
+            for idx in range(5)
+        ]
+
+        mock_get_manifests.return_value = manifests
+        mock_get_helm_releases.return_value = helm_releases
+
+        client = kubernetes.Client(TEST_KUBECONFIG)
+        addons = client.get_addons_by_label("label", "cluster1", "ns1")
+
+        mock_get_manifests.assert_called_once_with("label", "cluster1", "ns1")
+        mock_get_helm_releases.assert_called_once_with(
+            "label", "cluster1", "ns1"
+        )
+        self.assertEqual(manifests + helm_releases, addons)

--- a/magnum_capi_helm/tests/test_magnum_capi_helm.py
+++ b/magnum_capi_helm/tests/test_magnum_capi_helm.py
@@ -18,5 +18,7 @@ from magnum_capi_helm.tests import base
 
 class TestMagnumDriverLoads(base.TestCase):
     def test_get_driver(self):
-        cluster_driver = common.Driver.get_driver("vm", "ubuntu", "kubernetes")
+        cluster_driver = common.Driver.get_driver(
+            "vm", "capi-kubeadm-cloudinit", "kubernetes"
+        )
         self.assertIsInstance(cluster_driver, driver.Driver)

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps = -c{toxinidir}/lower-constraints.txt
 [testenv:pep8]
 commands =
     black {tox_root} -l 79
-    flake8 {posargs}
+    flake8 --ignore=W503 {posargs}
 
 [testenv:black]
 commands = black {tox_root} --check -l 79


### PR DESCRIPTION
This patch means the ClusterAPI driver can now successfully create and delete clusters.

You can see this being tested in Zuul in these
patches which change what we test to include cluster create: https://review.opendev.org/c/openstack/magnum-tempest-plugin/+/884366 https://review.opendev.org/c/openstack/magnum-tempest-plugin/+/872759

We add checks to see if the helm chart application has actually worked, by looking at the capi resoruces in the capi management cluster, and then update the DB state so the API tells the users the cluster is ready.

We can now create and delete clusters using the new driver! To be able to test this within devstack we have added a CAPI k8s cluster on the controller node that we will use to create all the magnum clusters.

To aid developer and reviewer testing we have added a script to bring up this environment within devstack:
devstack/contrib/new-devstack.sh

Future patches will fix up other APIs such as resizing the cluster and adding additional node pools.

Taken from:
https://review.opendev.org/c/openstack/magnum/+/851076

Co-Authored-By: Matt Pryor<matt@stackhpc.com>
Co-Authored-By: Tyler Christie<tyler@stackhpc.com>
Co-Authored-By: John Garbutt<johng@stackhpc.com>

Change-Id: If583bec63a2135486e393bacb16402f6821b7ede