### PR TITLE
Add missing label to cluster secrets

### DIFF
--- a/magnum_capi_helm/driver.py
+++ b/magnum_capi_helm/driver.py
@@ -417,10 +417,12 @@ class Driver(driver.Driver):
 
     def _k8s_resource_labels(self, cluster):
         # TODO(johngarbutt) need to check these are safe labels
+        name = self._get_chart_release_name(cluster)
         return {
             "magnum.openstack.org/project-id": cluster.project_id[:63],
             "magnum.openstack.org/user-id": cluster.user_id[:63],
             "magnum.openstack.org/cluster-uuid": cluster.uuid[:63],
+            "cluster.x-k8s.io/cluster-name": name,
         }
 
     def _create_appcred_secret(self, context, cluster):

--- a/magnum_capi_helm/tests/test_driver.py
+++ b/magnum_capi_helm/tests/test_driver.py
@@ -1334,6 +1334,7 @@ class ClusterAPIDriverTest(base.DbTestCase):
         self.driver._create_appcred_secret(self.context, self.cluster_obj)
 
         uuid = self.cluster_obj.uuid
+        name = "cluster-example-a-111111111111"
         mock_client.apply_secret.assert_called_once_with(
             "cluster-example-a-111111111111-cloud-credentials",
             {
@@ -1342,6 +1343,7 @@ class ClusterAPIDriverTest(base.DbTestCase):
                         "magnum.openstack.org/project-id": "fake_project",
                         "magnum.openstack.org/user-id": "fake_user",
                         "magnum.openstack.org/cluster-uuid": uuid,
+                        "cluster.x-k8s.io/cluster-name": name,
                     }
                 },
                 "stringData": {"cacert": "ca", "clouds.yaml": "appcred"},


### PR DESCRIPTION
From 1.5.0 onwards we need this extra label on the secrets: cluster.x-k8s.io/cluster-name