### PR TITLE
Rename config option namespace_suffix to namespace_prefix

### DIFF
--- a/magnum_capi_helm/conf.py
+++ b/magnum_capi_helm/conf.py
@@ -28,13 +28,13 @@ capi_helm_opts = [
         ),
     ),
     cfg.StrOpt(
-        "namespace_suffix",
+        "namespace_prefix",
         default="magnum",
         help=(
             "Resources for each openstack cluster are created in a "
             "separate namespace within the CAPI Management cluster "
-            "specified by the configuration: [capi_helm]kubeconfig_file "
-            "You should modify this suffix when two magnum deployments "
+            "specified by the configuration: [capi_helm]/kubeconfig_file "
+            "You should modify this prefix when two magnum deployments "
             "want to share a single CAPI management cluster."
         ),
     ),

--- a/magnum_capi_helm/driver.py
+++ b/magnum_capi_helm/driver.py
@@ -412,8 +412,8 @@ class Driver(driver.Driver):
         # We create clusters in a project-specific namespace
         # To generate the namespace, first sanitize the project id
         project_id = re.sub("[^a-z0-9]", "", cluster.project_id.lower())
-        suffix = CONF.capi_helm.namespace_suffix
-        return f"{suffix}-{project_id}"
+        prefix = CONF.capi_helm.namespace_prefix
+        return f"{prefix}-{project_id}"
 
     def _k8s_resource_labels(self, cluster):
         # TODO(johngarbutt) need to check these are safe labels


### PR DESCRIPTION
This option is used as a prefix, not a suffix.
Breaking change, but hopefully before others start to configure it.