### PR TITLE
Fix CI by pinning to working Magnum

### DIFF
--- a/magnum_capi_helm/driver.py
+++ b/magnum_capi_helm/driver.py
@@ -447,10 +447,7 @@ class Driver(driver.Driver):
         # Cluster API looks for specific named secrets for each of the CAs,
         # and generates them if they don't exist, so we create them here
         # with the correct certificates in
-        for (
-            name,
-            data,
-        ) in ca_certificates.get_certificate_string_data(
+        for (name, data,) in ca_certificates.get_certificate_string_data(
             context, cluster
         ).items():
             self._k8s_client.apply_secret(

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@
 # process, which may cause wedges in the gate later.
 
 pbr>=2.0 # Apache-2.0
-magnum
 oslo_log
 oslo_utils
+magnum<17.0.0 # test against 2023.1 for now

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ setenv =
    OS_STDOUT_CAPTURE=1
    OS_STDERR_CAPTURE=1
    OS_TEST_TIMEOUT=60
-deps = -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+deps = -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2023.1}
        -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands = stestr run {posargs}


### PR DESCRIPTION
The recently released mangum doesn't work with the latest oslo_db we start using. Lets pin to 2023.1 and its matching upper constraits for the moment.

Waiting on this release to fix 2023.2:
https://review.opendev.org/c/openstack/releases/+/897404