### PR TITLE
Apply boot disk values from Magnum config

### DIFF
--- a/magnum_capi_helm/driver.py
+++ b/magnum_capi_helm/driver.py
@@ -604,6 +604,25 @@ class Driver(driver.Driver):
             },
         }
 
+        # Add boot disk details, if defined in config file.
+        # Helm chart defaults to ephemeral disks, if unset.
+        if CONF.cinder.default_boot_volume_type:
+            disk_details = {
+                "controlPlane": {
+                    "machineRootVolume": {
+                        "volumeType": CONF.cinder.default_boot_volume_type,
+                        "diskSize": CONF.cinder.default_boot_volume_size or "",
+                    }
+                },
+                "nodeGroupDefaults": {
+                    "machineRootVolume": {
+                        "volumeType": CONF.cinder.default_boot_volume_type,
+                        "diskSize": CONF.cinder.default_boot_volume_size or "",
+                    }
+                },
+            }
+            values = helm.mergeconcat(values, disk_details)
+
         # Sometimes you need to add an extra network
         # for things like Cinder CSI CephFS Native
         extra_network_name = self._label(cluster, "extra_network_name", "")

--- a/magnum_capi_helm/driver.py
+++ b/magnum_capi_helm/driver.py
@@ -608,19 +608,22 @@ class Driver(driver.Driver):
         # for things like Cinder CSI CephFS Native
         extra_network_name = self._label(cluster, "extra_network_name", "")
         if extra_network_name:
-            values["nodeGroupDefaults"] = {
-                "machineNetworking": {
-                    "ports": [
-                        {},
-                        {
-                            "network": {
-                                "name": extra_network_name,
+            network_details = {
+                "nodeGroupDefaults": {
+                    "machineNetworking": {
+                        "ports": [
+                            {},
+                            {
+                                "network": {
+                                    "name": extra_network_name,
+                                },
+                                "securityGroups": [],
                             },
-                            "securityGroups": [],
-                        },
-                    ]
-                }
+                        ],
+                    },
+                },
             }
+            values = helm.mergeconcat(values, network_details)
 
         self._helm_client.install_or_upgrade(
             self._get_chart_release_name(cluster),


### PR DESCRIPTION
One commit to change `extra_network_name` to merge instead of overwrite the `nodeGroupDefaults` field.

Then, pass boot disk config through to CAPI helm charts, if it's set in Magnum config. A first pass, as there are several other relevant values in Magnum config for other volumes, and we may want to split by node type (worker, control plane).

Tests added, note that `test_create_cluster_boot_volume_extra_network` fails if the values do not merge into `nodeGroupDefaults`.
