### PR TITLE
Add support for Flatcar OS

### DIFF
--- a/magnum_capi_helm/tests/test_magnum_capi_helm.py
+++ b/magnum_capi_helm/tests/test_magnum_capi_helm.py
@@ -20,3 +20,9 @@ class TestMagnumDriverLoads(base.TestCase):
     def test_get_driver(self):
         cluster_driver = common.Driver.get_driver("vm", "ubuntu", "kubernetes")
         self.assertIsInstance(cluster_driver, driver.Driver)
+
+    def test_get_flatcar_driver(self):
+        cluster_driver = common.Driver.get_driver(
+            "vm", "flatcar", "kubernetes"
+        )
+        self.assertIsInstance(cluster_driver, driver.Driver)


### PR DESCRIPTION
Fetch os_distro metadata and pass to helm chart.

Depends on Helm chart flatcar support:
https://github.com/stackhpc/capi-helm-charts/pull/53