### PR TITLE
Move default helm to 0.1.4

### DIFF
--- a/magnum_capi_helm/conf.py
+++ b/magnum_capi_helm/conf.py
@@ -58,7 +58,7 @@ capi_helm_opts = [
     ),
     cfg.StrOpt(
         "default_helm_chart_version",
-        default="0.1.2-dev.0.main.55",
+        default="0.1.4",
         help=(
             "Version of the helm chart specified "
             "by the config: capi_driver.helm_chart_repo "


### PR DESCRIPTION
This includes flatcar support, updated addons and is better tested on Ubuntu jammy.