### PR TITLE
Support etcd on separate block device

### DIFF
--- a/devstack/contrib/new-devstack.sh
+++ b/devstack/contrib/new-devstack.sh
@@ -294,8 +294,8 @@ for K8S_IMAGE_KEY in $K8S_IMAGE_KEYS; do
       --labels \
 capi_helm_chart_version="$LATEST_TAG",\
 octavia_provider=ovn,\
-monitoring_enabled=True,\
-kube_dashboard_enabled=True \
+monitoring_enabled=true,\
+kube_dashboard_enabled=true \
       --external-network public \
       --master-flavor ds2G20 \
       --flavor ds2G20 \

--- a/devstack/contrib/new-devstack.sh
+++ b/devstack/contrib/new-devstack.sh
@@ -168,117 +168,6 @@ sudo chmod go+rw `tty`
 # Stack that stack!
 /opt/stack/stack.sh
 
-# Get latest capi-helm-charts tag
-LATEST_TAG=$(curl -fsL https://api.github.com/repos/stackhpc/capi-helm-charts/tags | jq -r '.[].name' | head -n 1)
-# Curl the dependencies URL
-DEPENDENCIES_JSON=$(curl -fsL https://github.com/stackhpc/capi-helm-charts/releases/download/$LATEST_TAG/dependencies.json)
-
-# Parse JSON into bash variables
-ADDON_PROVIDER=$(echo $DEPENDENCIES_JSON | jq -r '.["addon-provider"]')
-AZIMUTH_IMAGES_TAG=$(echo $DEPENDENCIES_JSON | jq -r '.["azimuth-images"]')
-CLUSTER_API=$(echo $DEPENDENCIES_JSON | jq -r '.["cluster-api"]')
-CLUSTER_API_JANITOR_OPENSTACK=$(echo $DEPENDENCIES_JSON | jq -r '.["cluster-api-janitor-openstack"]')
-CLUSTER_API_PROVIDER_OPENSTACK=$(echo $DEPENDENCIES_JSON | jq -r '.["cluster-api-provider-openstack"]')
-CERT_MANAGER=$(echo $DEPENDENCIES_JSON | jq -r '.["cert-manager"]')
-HELM=$(echo $DEPENDENCIES_JSON | jq -r '.["helm"]')
-SONOBUOY=$(echo $DEPENDENCIES_JSON | jq -r '.["sonobuoy"]')
-
-# # Install `kubectl` CLI
-curl -fsLo /tmp/kubectl "https://dl.k8s.io/release/$(curl -fsL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-sudo install -o root -g root -m 0755 /tmp/kubectl /usr/local/bin/kubectl
-
-# K3s has issues without apparmor, so we add it here
-sudo apt install -y apparmor apparmor-utils
-
-# Install k3s
-curl -fsL https://get.k3s.io | sudo bash -s - --disable traefik
-
-# copy kubeconfig file into standard location
-mkdir -p $HOME/.kube
-sudo cp /etc/rancher/k3s/k3s.yaml $HOME/.kube/config
-sudo chown $USER $HOME/.kube/config
-
-# Install helm
-curl -fsL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-
-{
-# Install cert manager
-helm upgrade cert-manager cert-manager \
-	--install \
-	--namespace cert-manager \
-	--create-namespace \
-	--repo https://charts.jetstack.io \
-	--version $CERT_MANAGER \
-	--set installCRDs=true \
-	--wait \
-	--timeout 10m
-} || {
-	kubectl -n cert-manager get pods |  awk '$1 && $1!="NAME" { print $1 }' | xargs -n1 kubectl -n cert-manager logs
-		exit
-	}
-
-# Install clusterctl
-curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/$CLUSTER_API/clusterctl-linux-amd64 -o clusterctl
-sudo install -o root -g root -m 0755 clusterctl /usr/local/bin/clusterctl
-
-# Install Cluster API resources
-# using the matching tested values here:
-# https://github.com/stackhpc/capi-helm-charts/blob/main/dependencies.json
-clusterctl init \
-    --core cluster-api:$CLUSTER_API \
-    --bootstrap kubeadm:$CLUSTER_API \
-    --control-plane kubeadm:$CLUSTER_API \
-    --infrastructure openstack:$CLUSTER_API_PROVIDER_OPENSTACK
-
-# Install addon manager
-helm upgrade cluster-api-addon-provider cluster-api-addon-provider \
---install \
---repo https://stackhpc.github.io/cluster-api-addon-provider \
---version $ADDON_PROVIDER \
---namespace capi-addon-system \
---create-namespace \
---wait \
---timeout 10m
-
-# Create a Flavor
-
-pip install python-magnumclient
-
-# Curl the manifest
-AZIMUTH_IMAGES=$(curl -fsL "https://github.com/stackhpc/azimuth-images/releases/download/$AZIMUTH_IMAGES_TAG/manifest.json")
-
-# Kubernetes 1.27 image
-K8S_1_27_NAME=$(echo "$AZIMUTH_IMAGES" | jq -r '.["kubernetes-1-27-jammy"].name')
-K8S_1_27_URL=$(echo "$AZIMUTH_IMAGES" | jq -r '.["kubernetes-1-27-jammy"].url')
-K8S_1_27_VERSION=$(echo "$AZIMUTH_IMAGES" | jq -r '.["kubernetes-1-27-jammy"].kubernetes_version')
-
-curl -o "$K8S_1_27_NAME.qcow2" "$K8S_1_27_URL"
-
-openstack image create "$K8S_1_27_NAME" \
---file "$K8S_1_27_NAME.qcow2" \
---disk-format qcow2 \
---container-format bare \
---public
-
-openstack image set "$K8S_1_27_NAME" --os-distro ubuntu --os-version 22.04
-openstack image set "$K8S_1_27_NAME" --property kube_version="$K8S_1_27_VERSION"
-
-# Kubernetes 1.28 image
-K8S_1_28_NAME=$(echo "$AZIMUTH_IMAGES" | jq -r '.["kubernetes-1-28-jammy"].name')
-K8S_1_28_URL=$(echo "$AZIMUTH_IMAGES" | jq -r '.["kubernetes-1-28-jammy"].url')
-K8S_1_28_VERSION=$(echo "$AZIMUTH_IMAGES" | jq -r '.["kubernetes-1-28-jammy"].kubernetes_version')
-
-curl -o "$K8S_1_28_NAME.qcow2" "$K8S_1_28_URL"
-
-openstack image create "$K8S_1_28_NAME" \
---file "$K8S_1_28_NAME.qcow2" \
---disk-format qcow2 \
---container-format bare \
---public
-
-openstack image set "$K8S_1_28_NAME" --os-distro ubuntu --os-version 22.04
-openstack image set "$K8S_1_28_NAME" --property kube_version="$K8S_1_28_VERSION"
-
 #
 # Install this checkout and restart the Magnum services
 #
@@ -297,45 +186,127 @@ if [[ ":$PATH:" != *":$new_path:"* ]]; then
   echo 'export PATH="$PATH:'"$new_path"'"' >> ~/.bashrc
 fi
 
-# Kubernetes 1.27 template
-K8S_1_27_IMAGE_ID=$(openstack image show $K8S_1_27_NAME -c id -f value)
+# Get latest capi-helm-charts tag
+LATEST_TAG=$(curl -fsL https://api.github.com/repos/stackhpc/capi-helm-charts/tags | jq -r '.[0].name')
+# Curl the dependencies URL
+DEPENDENCIES_JSON=$(curl -fsL https://github.com/stackhpc/capi-helm-charts/releases/download/$LATEST_TAG/dependencies.json)
 
-# Kubernetes 1.27 template
-openstack coe cluster template create k8s-1-27-template \
---coe kubernetes \
---image "$K8S_1_27_IMAGE_ID" \
---labels \
+# Parse JSON into bash variables
+ADDON_PROVIDER=$(echo $DEPENDENCIES_JSON | jq -r '.["addon-provider"]')
+AZIMUTH_IMAGES_TAG=$(echo $DEPENDENCIES_JSON | jq -r '.["azimuth-images"]')
+CLUSTER_API=$(echo $DEPENDENCIES_JSON | jq -r '.["cluster-api"]')
+CLUSTER_API_JANITOR_OPENSTACK=$(echo $DEPENDENCIES_JSON | jq -r '.["cluster-api-janitor-openstack"]')
+CLUSTER_API_PROVIDER_OPENSTACK=$(echo $DEPENDENCIES_JSON | jq -r '.["cluster-api-provider-openstack"]')
+CERT_MANAGER=$(echo $DEPENDENCIES_JSON | jq -r '.["cert-manager"]')
+HELM=$(echo $DEPENDENCIES_JSON | jq -r '.["helm"]')
+SONOBUOY=$(echo $DEPENDENCIES_JSON | jq -r '.["sonobuoy"]')
+
+# # Install `kubectl` CLI
+curl -fsLo /tmp/kubectl "https://dl.k8s.io/release/$(curl -fsL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+sudo install -o root -g root -m 0755 /tmp/kubectl /usr/local/bin/kubectl
+
+# Install k3s
+curl -fsL https://get.k3s.io | sudo bash -s - --disable traefik
+
+# copy kubeconfig file into standard location
+mkdir -p $HOME/.kube
+sudo cp /etc/rancher/k3s/k3s.yaml $HOME/.kube/config
+sudo chown $USER $HOME/.kube/config
+
+# Install helm
+curl -fsL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+# Install cert manager
+{
+    helm upgrade cert-manager cert-manager \
+      --install \
+      --namespace cert-manager \
+      --create-namespace \
+      --repo https://charts.jetstack.io \
+      --version $CERT_MANAGER \
+      --set installCRDs=true \
+      --wait \
+      --timeout 10m
+} || {
+    kubectl -n cert-manager get pods |  awk '$1 && $1!="NAME" { print $1 }' | xargs -n1 kubectl -n cert-manager logs
+    exit
+}
+
+# Install clusterctl
+curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/$CLUSTER_API/clusterctl-linux-amd64 -o clusterctl
+sudo install -o root -g root -m 0755 clusterctl /usr/local/bin/clusterctl
+
+# Install Cluster API resources
+# using the matching tested values here:
+# https://github.com/stackhpc/capi-helm-charts/blob/main/dependencies.json
+clusterctl init \
+    --core cluster-api:$CLUSTER_API \
+    --bootstrap kubeadm:$CLUSTER_API \
+    --control-plane kubeadm:$CLUSTER_API \
+    --infrastructure openstack:$CLUSTER_API_PROVIDER_OPENSTACK
+
+# Install addon manager
+helm upgrade cluster-api-addon-provider cluster-api-addon-provider \
+  --install \
+  --repo https://stackhpc.github.io/cluster-api-addon-provider \
+  --version $ADDON_PROVIDER \
+  --namespace capi-addon-system \
+  --create-namespace \
+  --wait \
+  --timeout 10m
+
+pip install python-magnumclient
+
+# Configure OpenStack auth
+source /opt/stack/openrc admin admin
+
+# Create a flavor that is *just* big enough for Kubernetes
+openstack flavor create ds2G20 --ram 2048 --disk 20 --id d5 --vcpus 2 --public
+
+# Curl the manifest
+AZIMUTH_IMAGES=$(curl -fsL "https://github.com/stackhpc/azimuth-images/releases/download/$AZIMUTH_IMAGES_TAG/manifest.json")
+
+# Get the keys of the Kubernetes images
+K8S_IMAGE_KEYS="$(echo "$AZIMUTH_IMAGES" | jq -r '. | with_entries(select(.value | has("kubernetes_version"))) | keys | sort | .[]')"
+
+# For each Kubernetes image, upload the image and create a corresponding COE template
+for K8S_IMAGE_KEY in $K8S_IMAGE_KEYS; do
+    K8S_IMAGE_NAME="$(echo "$AZIMUTH_IMAGES" | jq -r ".[\"$K8S_IMAGE_KEY\"].name")"
+    K8S_IMAGE_URL="$(echo "$AZIMUTH_IMAGES" | jq -r ".[\"$K8S_IMAGE_KEY\"].url")"
+    K8S_IMAGE_VERSION="$(echo "$AZIMUTH_IMAGES" | jq -r ".[\"$K8S_IMAGE_KEY\"].kubernetes_version")"
+
+    # Download the image and upload it to Glance
+    curl -fsSLo "$K8S_IMAGE_NAME.qcow2" "$K8S_IMAGE_URL"
+    openstack image create "$K8S_IMAGE_NAME" \
+      --file "$K8S_IMAGE_NAME.qcow2" \
+      --disk-format qcow2 \
+      --container-format bare \
+      --public
+    rm "$K8S_IMAGE_NAME.qcow2"
+    openstack image set "$K8S_IMAGE_NAME" --os-distro ubuntu --os-version 22.04
+    openstack image set "$K8S_IMAGE_NAME" --property kube_version="$K8S_IMAGE_VERSION"
+    K8S_IMAGE_ID=$(openstack image show $K8S_IMAGE_NAME -c id -f value)
+
+    # Create a COE template for the image
+    openstack coe cluster template create "k8s-${K8S_IMAGE_VERSION//./-}" \
+      --coe kubernetes \
+      --image "$K8S_IMAGE_ID" \
+      --labels \
 capi_helm_chart_version="$LATEST_TAG",\
 octavia_provider=ovn,\
 monitoring_enabled=True,\
 kube_dashboard_enabled=True \
---external-network public \
---master-flavor ds2G20 \
---flavor ds2G20 \
---public \
---master-lb-enabled
-
-# Kubernetes 1.28 template
-K8S_1_28_IMAGE_ID=$(openstack image show $K8S_1_28_NAME -c id -f value)
-
-openstack coe cluster template create k8s-1-28-template \
---coe kubernetes \
---image "$K8S_1_28_IMAGE_ID" \
---labels \
-capi_helm_chart_version="$LATEST_TAG",\
-octavia_provider=ovn,\
-monitoring_enabled=True,\
-kube_dashboard_enabled=True \
---external-network public \
---master-flavor ds2G20 \
---flavor ds2G20 \
---public \
---master-lb-enabled
+      --external-network public \
+      --master-flavor ds2G20 \
+      --flavor ds2G20 \
+      --public \
+      --master-lb-enabled
+done
 
 # You can test it like this:
 #  openstack coe cluster create devstacktest \
-#   --cluster-template new_driver \
-#   --master-count 1 \
-#   --node-count 2
+#    --cluster-template k8s-v1-28-5 \
+#    --master-count 1 \
+#    --node-count 2
 #  openstack coe cluster list
 #  openstack coe cluster config devstacktest

--- a/magnum_capi_helm/conf.py
+++ b/magnum_capi_helm/conf.py
@@ -58,7 +58,7 @@ capi_helm_opts = [
     ),
     cfg.StrOpt(
         "default_helm_chart_version",
-        default="0.1.4",
+        default="0.2.0",
         help=(
             "Version of the helm chart specified "
             "by the config: capi_driver.helm_chart_repo "

--- a/magnum_capi_helm/tests/test_driver.py
+++ b/magnum_capi_helm/tests/test_driver.py
@@ -1159,6 +1159,7 @@ class ClusterAPIDriverTest(base.DbTestCase):
                 },
                 "dnsNameservers": ["8.8.1.1"],
             },
+            "etcd": {},
             "apiServer": {
                 "enableLoadBalancer": True,
                 "loadBalancerProvider": "amphora",

--- a/magnum_capi_helm/tests/test_driver.py
+++ b/magnum_capi_helm/tests/test_driver.py
@@ -1577,6 +1577,195 @@ class ClusterAPIDriverTest(base.DbTestCase):
             self.driver, self.context, self.cluster_obj
         )
 
+    @mock.patch.object(driver.Driver, "_validate_allowed_flavor")
+    @mock.patch.object(
+        driver.Driver, "_ensure_certificate_secrets", autospec=True
+    )
+    @mock.patch.object(driver.Driver, "_create_appcred_secret", autospec=True)
+    @mock.patch.object(kubernetes.Client, "load", autospec=True)
+    @mock.patch.object(driver.Driver, "_get_image_details", autospec=True)
+    @mock.patch.object(helm.Client, "install_or_upgrade", autospec=True)
+    def test_create_cluster_etcd_block_device(
+        self,
+        mock_install,
+        mock_image,
+        mock_load,
+        mock_appcred,
+        mock_certs,
+        mock_validate_allowed_flavor,
+    ):
+        mock_image.return_value = ("imageid1", "1.27.4", "ubuntu")
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_load.return_value = mock_client
+
+        self.cluster_obj.cluster_template.labels.update(
+            {
+                "etcd_blockdevice_size": "10",
+                "etcd_blockdevice_volume_type": "nvme",
+            }
+        )
+
+        self.driver.create_cluster(self.context, self.cluster_obj, 10)
+
+        # Get standard values and modify them to match this test
+        expected_values = self._get_cluster_helm_standard_values()
+        expected_values["etcd"] = {
+            "blockDevice": {
+                "size": 10,
+                "type": "Volume",
+                "volumeType": "nvme",
+            }
+        }
+
+        mock_install.assert_called_once_with(
+            self.driver._helm_client,
+            "cluster-example-a-111111111111",
+            "openstack-cluster",
+            mock.ANY,
+            repo=CONF.capi_helm.helm_chart_repo,
+            version=CONF.capi_helm.default_helm_chart_version,
+            namespace="magnum-fakeproject",
+        )
+
+        helm_install_values = mock_install.call_args[0][3]
+        self.assertDictEqual(helm_install_values, expected_values)
+
+        mock_client.ensure_namespace.assert_called_once_with(
+            "magnum-fakeproject"
+        )
+        mock_appcred.assert_called_once_with(
+            self.driver, self.context, self.cluster_obj
+        )
+        mock_certs.assert_called_once_with(
+            self.driver, self.context, self.cluster_obj
+        )
+
+    @mock.patch.object(driver.Driver, "_validate_allowed_flavor")
+    @mock.patch.object(
+        driver.Driver, "_ensure_certificate_secrets", autospec=True
+    )
+    @mock.patch.object(driver.Driver, "_create_appcred_secret", autospec=True)
+    @mock.patch.object(kubernetes.Client, "load", autospec=True)
+    @mock.patch.object(driver.Driver, "_get_image_details", autospec=True)
+    @mock.patch.object(helm.Client, "install_or_upgrade", autospec=True)
+    def test_create_cluster_etcd_block_device_local(
+        self,
+        mock_install,
+        mock_image,
+        mock_load,
+        mock_appcred,
+        mock_certs,
+        mock_validate_allowed_flavor,
+    ):
+        mock_image.return_value = ("imageid1", "1.27.4", "ubuntu")
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_load.return_value = mock_client
+
+        self.cluster_obj.cluster_template.labels.update(
+            {
+                "etcd_blockdevice_size": "10",
+                "etcd_blockdevice_type": "local",
+            }
+        )
+
+        self.driver.create_cluster(self.context, self.cluster_obj, 10)
+
+        # Get standard values and modify them to match this test
+        expected_values = self._get_cluster_helm_standard_values()
+        expected_values["etcd"] = {
+            "blockDevice": {
+                "size": 10,
+                "type": "Local",
+            }
+        }
+
+        mock_install.assert_called_once_with(
+            self.driver._helm_client,
+            "cluster-example-a-111111111111",
+            "openstack-cluster",
+            mock.ANY,
+            repo=CONF.capi_helm.helm_chart_repo,
+            version=CONF.capi_helm.default_helm_chart_version,
+            namespace="magnum-fakeproject",
+        )
+
+        helm_install_values = mock_install.call_args[0][3]
+        self.assertDictEqual(helm_install_values, expected_values)
+
+        mock_client.ensure_namespace.assert_called_once_with(
+            "magnum-fakeproject"
+        )
+        mock_appcred.assert_called_once_with(
+            self.driver, self.context, self.cluster_obj
+        )
+        mock_certs.assert_called_once_with(
+            self.driver, self.context, self.cluster_obj
+        )
+
+    @mock.patch.object(driver.Driver, "_validate_allowed_flavor")
+    @mock.patch.object(
+        driver.Driver, "_ensure_certificate_secrets", autospec=True
+    )
+    @mock.patch.object(driver.Driver, "_create_appcred_secret", autospec=True)
+    @mock.patch.object(kubernetes.Client, "load", autospec=True)
+    @mock.patch.object(driver.Driver, "_get_image_details", autospec=True)
+    @mock.patch.object(helm.Client, "install_or_upgrade", autospec=True)
+    def test_create_cluster_etcd_block_device_legacy_labels(
+        self,
+        mock_install,
+        mock_image,
+        mock_load,
+        mock_appcred,
+        mock_certs,
+        mock_validate_allowed_flavor,
+    ):
+        mock_image.return_value = ("imageid1", "1.27.4", "ubuntu")
+        mock_client = mock.MagicMock(spec=kubernetes.Client)
+        mock_load.return_value = mock_client
+
+        # Test the legacy labels for etcd volume size
+        self.cluster_obj.cluster_template.labels.update(
+            {
+                "etcd_volume_size": "10",
+                "etcd_volume_type": "nvme",
+            }
+        )
+
+        self.driver.create_cluster(self.context, self.cluster_obj, 10)
+
+        # Get standard values and modify them to match this test
+        expected_values = self._get_cluster_helm_standard_values()
+        expected_values["etcd"] = {
+            "blockDevice": {
+                "size": 10,
+                "type": "Volume",
+                "volumeType": "nvme",
+            }
+        }
+
+        mock_install.assert_called_once_with(
+            self.driver._helm_client,
+            "cluster-example-a-111111111111",
+            "openstack-cluster",
+            mock.ANY,
+            repo=CONF.capi_helm.helm_chart_repo,
+            version=CONF.capi_helm.default_helm_chart_version,
+            namespace="magnum-fakeproject",
+        )
+
+        helm_install_values = mock_install.call_args[0][3]
+        self.assertDictEqual(helm_install_values, expected_values)
+
+        mock_client.ensure_namespace.assert_called_once_with(
+            "magnum-fakeproject"
+        )
+        mock_appcred.assert_called_once_with(
+            self.driver, self.context, self.cluster_obj
+        )
+        mock_certs.assert_called_once_with(
+            self.driver, self.context, self.cluster_obj
+        )
+
     @mock.patch.object(app_creds, "get_app_cred_string_data")
     @mock.patch.object(kubernetes.Client, "load")
     def test_create_appcred_secret(self, mock_load, mock_sd):

--- a/tox.ini
+++ b/tox.ini
@@ -21,11 +21,11 @@ deps = -c{toxinidir}/lower-constraints.txt
 
 [testenv:pep8]
 commands =
-    black {tox_root} -l 79
+    black {toxinidir} -l 79
     flake8 --ignore=W503 {posargs}
 
 [testenv:black]
-commands = black {tox_root} --check -l 79
+commands = black {toxinidir} --check -l 79
 allowlist_externals = black
 
 [testenv:venv]


### PR DESCRIPTION
Supports using a separate block device for etcd. Can be either a Cinder volume or ephemeral storage.