### PR TITLE
Pin to 2023.2 upper requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@
 pbr>=2.0 # Apache-2.0
 oslo_log
 oslo_utils
-magnum
+magnum==17.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@
 pbr>=2.0 # Apache-2.0
 oslo_log
 oslo_utils
-magnum==17.0.2
+magnum

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,3 +10,6 @@ oslotest>=1.10.0 # Apache-2.0
 stestr>=1.0.0 # Apache-2.0
 testtools>=1.4.0 # MIT
 black<25.0.0
+
+# pin magnum while out of tree
+magnum==17.0.2

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ setenv =
    OS_STDOUT_CAPTURE=1
    OS_STDERR_CAPTURE=1
    OS_TEST_TIMEOUT=60
-deps = -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
+deps = -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2023.2}
        -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands = stestr run {posargs}


### PR DESCRIPTION
The bump of oslo has broken tests against older Magnum 17.x.x
https://github.com/openstack/requirements/commit/30a749770e423696dc53764d65c6fb9ac3d0a78c

Lets work around this for now.