### PR TITLE
Sanitise storageclasses

### DIFF
--- a/magnum_capi_helm/driver.py
+++ b/magnum_capi_helm/driver.py
@@ -691,7 +691,7 @@ class Driver(driver.Driver):
 
         for volume_type in volume_types:
             storage_class = {
-                "name": volume_type,
+                "name": driver_utils.sanitized_name(volume_type),
                 "reclaimPolicy": reclaim_policy,
                 "allowVolumeExpansion": allow_expansion,
                 "availabilityZone": region_name,

--- a/magnum_capi_helm/driver_utils.py
+++ b/magnum_capi_helm/driver_utils.py
@@ -33,7 +33,7 @@ def sanitized_name(name, suffix=None):
     return re.sub(
         "[^a-z0-9]+",
         "-",
-        (f"{name}-{suffix}" if suffix else name).lower(),
+        (f"{name}-{suffix}" if suffix else name).lower().strip("-"),
     )
 
 

--- a/magnum_capi_helm/driver_utils.py
+++ b/magnum_capi_helm/driver_utils.py
@@ -33,8 +33,8 @@ def sanitized_name(name, suffix=None):
     return re.sub(
         "[^a-z0-9]+",
         "-",
-        (f"{name}-{suffix}" if suffix else name).lower().strip("-"),
-    )
+        (f"{name}-{suffix}" if suffix else name).lower(),
+    ).strip("-")
 
 
 def chart_release_name(cluster):

--- a/magnum_capi_helm/tests/test_driver.py
+++ b/magnum_capi_helm/tests/test_driver.py
@@ -2031,7 +2031,7 @@ class ClusterAPIDriverTest(base.DbTestCase):
         CONF.capi_helm.csi_cinder_default_volume_type = None
         mock_osc_rn.return_value = "middle_earth_east"
         mock_vol_type_1 = mock.MagicMock()
-        mock_vol_type_1.name = "type1"
+        mock_vol_type_1.name = "__TYPE1__"
         mock_vol_type_2 = mock.MagicMock()
         mock_vol_type_2.name = "type2"
         mock_vol_type_3 = mock.MagicMock()

--- a/magnum_capi_helm/tests/test_driver.py
+++ b/magnum_capi_helm/tests/test_driver.py
@@ -1114,9 +1114,9 @@ class ClusterAPIDriverTest(base.DbTestCase):
         self.assertTrue(result)
 
     def test_get_kube_dash_enabled_from_template(self):
-        self.cluster_obj.cluster_template.labels["kube_dashboard_enabled"] = (
-            "false"
-        )
+        self.cluster_obj.cluster_template.labels[
+            "kube_dashboard_enabled"
+        ] = "false"
 
         result = self.driver._get_kube_dash_enabled(self.cluster_obj)
 
@@ -1128,9 +1128,9 @@ class ClusterAPIDriverTest(base.DbTestCase):
         self.assertEqual(CONF.capi_helm.default_helm_chart_version, version)
 
     def test_get_chart_version_from_template(self):
-        self.cluster_obj.cluster_template.labels["capi_helm_chart_version"] = (
-            "1.42.0"
-        )
+        self.cluster_obj.cluster_template.labels[
+            "capi_helm_chart_version"
+        ] = "1.42.0"
 
         version = self.driver._get_chart_version(self.cluster_obj)
 
@@ -1629,9 +1629,9 @@ class ClusterAPIDriverTest(base.DbTestCase):
         mock_client = mock.MagicMock(spec=kubernetes.Client)
         mock_load.return_value = mock_client
 
-        self.cluster_obj.cluster_template.labels["auto_healing_enabled"] = (
-            "false"
-        )
+        self.cluster_obj.cluster_template.labels[
+            "auto_healing_enabled"
+        ] = "false"
 
         self.driver.create_cluster(self.context, self.cluster_obj, 10)
 
@@ -2049,7 +2049,7 @@ class ClusterAPIDriverTest(base.DbTestCase):
             self.context, self.cluster_obj
         )
         default_storage_class = storage_classes["defaultStorageClass"]
-        volume_type = default_storage_class["volumeType"]
+        volume_type = default_storage_class["name"]
         self.assertEqual("type1", volume_type)
 
     @mock.patch.object(helm.Client, "uninstall_release")

--- a/magnum_capi_helm/tests/test_driver.py
+++ b/magnum_capi_helm/tests/test_driver.py
@@ -1114,9 +1114,9 @@ class ClusterAPIDriverTest(base.DbTestCase):
         self.assertTrue(result)
 
     def test_get_kube_dash_enabled_from_template(self):
-        self.cluster_obj.cluster_template.labels[
-            "kube_dashboard_enabled"
-        ] = "false"
+        self.cluster_obj.cluster_template.labels["kube_dashboard_enabled"] = (
+            "false"
+        )
 
         result = self.driver._get_kube_dash_enabled(self.cluster_obj)
 
@@ -1128,9 +1128,9 @@ class ClusterAPIDriverTest(base.DbTestCase):
         self.assertEqual(CONF.capi_helm.default_helm_chart_version, version)
 
     def test_get_chart_version_from_template(self):
-        self.cluster_obj.cluster_template.labels[
-            "capi_helm_chart_version"
-        ] = "1.42.0"
+        self.cluster_obj.cluster_template.labels["capi_helm_chart_version"] = (
+            "1.42.0"
+        )
 
         version = self.driver._get_chart_version(self.cluster_obj)
 
@@ -1629,9 +1629,9 @@ class ClusterAPIDriverTest(base.DbTestCase):
         mock_client = mock.MagicMock(spec=kubernetes.Client)
         mock_load.return_value = mock_client
 
-        self.cluster_obj.cluster_template.labels[
-            "auto_healing_enabled"
-        ] = "false"
+        self.cluster_obj.cluster_template.labels["auto_healing_enabled"] = (
+            "false"
+        )
 
         self.driver.create_cluster(self.context, self.cluster_obj, 10)
 


### PR DESCRIPTION
We need to sanitise storageclass resource names to avoid:
```
status:
  failureMessage: "Error: 2 errors occurred:\n\t* StorageClass.storage.k8s.io \"Ceph-HDD\"
    is invalid: metadata.name: Invalid value: \"Ceph-HDD\": a lowercase RFC 1123 subdomain
    must consist of lower case alphanumeric characters, '-' or '.', and must start
    and end with an alphanumeric character (e.g. 'example.com', regex used for validation
    is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')\n\t* StorageClass.storage.k8s.io
    \"__DEFAULT__\" is invalid: metadata.name: Invalid value: \"__DEFAULT__\": a lowercase
    RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or
    '.', and must start and end with an alphanumeric character (e.g. 'example.com',
    regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')\n\n\n"
  phase: Failed
```
on `csi-cinder-storageclass` manifests