### PR TITLE
Appcred authtype

### DIFF
--- a/magnum_capi_helm/common/app_creds.py
+++ b/magnum_capi_helm/common/app_creds.py
@@ -73,6 +73,7 @@ def _create_app_cred(context, cluster):
                     "application_credential_id": app_cred.id,
                     "application_credential_secret": app_cred.secret,
                 },
+	       "auth_type": "v3applicationcredential",
             },
         },
     }

--- a/magnum_capi_helm/common/app_creds.py
+++ b/magnum_capi_helm/common/app_creds.py
@@ -73,7 +73,7 @@ def _create_app_cred(context, cluster):
                     "application_credential_id": app_cred.id,
                     "application_credential_secret": app_cred.secret,
                 },
-	       "auth_type": "v3applicationcredential",
+                "auth_type": "v3applicationcredential",
             },
         },
     }

--- a/magnum_capi_helm/tests/common/test_app_creds.py
+++ b/magnum_capi_helm/tests/common/test_app_creds.py
@@ -67,6 +67,7 @@ class TestAppCreds(base.DbTestCase):
                         "application_credential_secret": "pass",
                         "auth_url": "http://keystone",
                     },
+		    "auth_type" : "v3applicationcredential",
                     "identity_api_version": 3,
                     "interface": "public",
                     "region_name": "cinder",

--- a/magnum_capi_helm/tests/common/test_app_creds.py
+++ b/magnum_capi_helm/tests/common/test_app_creds.py
@@ -67,7 +67,7 @@ class TestAppCreds(base.DbTestCase):
                         "application_credential_secret": "pass",
                         "auth_url": "http://keystone",
                     },
-		    "auth_type" : "v3applicationcredential",
+                    "auth_type": "v3applicationcredential",
                     "identity_api_version": 3,
                     "interface": "public",
                     "region_name": "cinder",


### PR DESCRIPTION
we add the auth_type to the application credential secret for `capi-janitor-system`, as if it is not provided then upon cluster deletion we see: 
```
Traceback (most recent call last):
  File "/venv/lib/python3.10/site-packages/capi_janitor/openstack/operator.py", line 266, in wrapper
    result = await handler(**kwargs)
  File "/venv/lib/python3.10/site-packages/capi_janitor/openstack/operator.py", line 381, in on_openstackcluster_event
    await purge_openstack_resources(
  File "/venv/lib/python3.10/site-packages/capi_janitor/openstack/operator.py", line 152, in purge_openstack_resources
    async with openstack.Cloud.from_clouds(clouds, cacert = cacert) as cloud:
  File "/venv/lib/python3.10/site-packages/capi_janitor/openstack/openstack.py", line 219, in from_clouds
    if config["auth_type"] != "v3applicationcredential":
KeyError: 'auth_type'
```