### PR TITLE
Remove dependence on nova_client endpointURL

### DIFF
--- a/magnum_capi_helm/common/app_creds.py
+++ b/magnum_capi_helm/common/app_creds.py
@@ -62,7 +62,7 @@ def _create_app_cred(context, cluster):
             "openstack": {
                 "identity_api_version": 3,
                 "region_name": osc.cinder_region_name(),
-                "interface": CONF.nova_client.endpoint_type.replace("URL", ""),
+                "interface": CONF.capi_helm.app_cred_interface_type,
                 # This config item indicates whether TLS should be
                 # verified when connecting to the OpenStack API
                 "verify": CONF.drivers.verify_ca,

--- a/magnum_capi_helm/conf.py
+++ b/magnum_capi_helm/conf.py
@@ -121,7 +121,7 @@ capi_helm_opts = [
         "app_cred_interface_type",
         default="public",
         help=(
-            "The value use in the interface field of "
+            "The value to use in the interface field of "
             "generated application credentials."
         ),
     ),

--- a/magnum_capi_helm/conf.py
+++ b/magnum_capi_helm/conf.py
@@ -117,6 +117,14 @@ capi_helm_opts = [
             "volume binding and dynamic provisioning should occur."
         ),
     ),
+    cfg.StrOpt(
+        "app_cred_interface_type",
+        default="public",
+        help=(
+            "The value use in the interface field of "
+            "generated application credentials."
+        ),
+    ),
 ]
 
 CONF = cfg.CONF


### PR DESCRIPTION
Adds a new config option which defaults to
```
[capi_helm]
app_cred_interface_type = public
```
this avoids having to set
```
[nova_client]
endpoint_type = publicURL
```
in `magnum.conf` to obtain the same behaviour.